### PR TITLE
Remove WeakRegistry references (class split and removed in Pharo 12)

### DIFF
--- a/src/ODBC-Core/ManifestDatabaseConnectionBase.class.st
+++ b/src/ODBC-Core/ManifestDatabaseConnectionBase.class.st
@@ -8,19 +8,21 @@ For documentation evaluate:
 	SmalltalkSystem help: 'databaseconnectivity'
 "
 Class {
-	#name : #ManifestDatabaseConnectionBase,
-	#superclass : #PackageManifest,
-	#category : #'ODBC-Core-Manifest'
+	#name : 'ManifestDatabaseConnectionBase',
+	#superclass : 'PackageManifest',
+	#category : 'ODBC-Core-Manifest',
+	#package : 'ODBC-Core',
+	#tag : 'Manifest'
 }
 
-{ #category : #'code-critics' }
+{ #category : 'code-critics' }
 ManifestDatabaseConnectionBase class >> ruleBadMessageRule2V1FalsePositive [
 
 	<ignoreForCoverage>
 	^ #(#(#(#RGMethodDefinition #(#ODBCField #shouldTranslate:class: #false)) #'2023-03-07T00:15:07.698506+01:00') )
 ]
 
-{ #category : #'code-critics' }
+{ #category : 'code-critics' }
 ManifestDatabaseConnectionBase class >> ruleEquivalentSuperclassMethodsRuleV1FalsePositive [
 
 	<ignoreForCoverage>

--- a/src/ODBC-Core/ODBCAbstractRow.class.st
+++ b/src/ODBC-Core/ODBCAbstractRow.class.st
@@ -12,8 +12,8 @@ Instance Variables:
 Based on DBAbstractRow from Dolphin Smalltalk Database Connection package.
 "
 Class {
-	#name : #ODBCAbstractRow,
-	#superclass : #Object,
+	#name : 'ODBCAbstractRow',
+	#superclass : 'Object',
 	#instVars : [
 		'columns',
 		'contents',
@@ -23,16 +23,18 @@ Class {
 	#pools : [
 		'ODBCConstants'
 	],
-	#category : #'ODBC-Core-Base'
+	#category : 'ODBC-Core-Base',
+	#package : 'ODBC-Core',
+	#tag : 'Base'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 ODBCAbstractRow class >> isAbstract [
 
 	^ self == ODBCAbstractRow
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 ODBCAbstractRow >> = comparand [
 	"Answer whether the receiver and the <Object>, comparand,
 	are considered equivalent."
@@ -41,21 +43,21 @@ ODBCAbstractRow >> = comparand [
 		  self contents = comparand contents ]
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 ODBCAbstractRow >> asObject [
 	"Private - Answer the receiver as an instance of DBRow containing the receiver's values."
 
 	^ self subclassResponsibility
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCAbstractRow >> at: aString [
 	"Answer the field named aSymbol from the receiver."
 
 	^ self atIndex: (self selectors at: aString)
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCAbstractRow >> at: aString ifAbsent: exceptionHandler [
 	"Answer the field named aString from the receiver.  If the field is not present,
 	answer the result of evaluating the niladic valuable, exceptionHandler."
@@ -64,7 +66,7 @@ ODBCAbstractRow >> at: aString ifAbsent: exceptionHandler [
 		  (self selectors at: aString ifAbsent: [ ^ exceptionHandler value ])
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCAbstractRow >> at: key ifPresent: operation [
 	"Answer the result of evaluating the monadic valuable, operation, if
 	the argument, key, is the key of an element in the receiver, with that
@@ -73,7 +75,7 @@ ODBCAbstractRow >> at: key ifPresent: operation [
 	^ operation value: (self at: key ifAbsent: [ ^ nil ])
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCAbstractRow >> at: aString put: anObject [
 	"Set the field named aSymbol to anObject.
 	Answer the argument."
@@ -81,14 +83,14 @@ ODBCAbstractRow >> at: aString put: anObject [
 	^ self atIndex: (self selectors at: aString) put: anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCAbstractRow >> atIndex: anInteger [
 	"Answer the field whose column index is anInteger."
 
 	^ self contents at: anInteger
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCAbstractRow >> atIndex: anInteger put: anObject [
 	"Set the field whose column index is anInteger to anObject.
 	Answer the argument."
@@ -96,7 +98,7 @@ ODBCAbstractRow >> atIndex: anInteger put: anObject [
 	^ self contents at: anInteger put: anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCAbstractRow >> buildSelectors [
 
 	| cols |
@@ -110,26 +112,26 @@ ODBCAbstractRow >> buildSelectors [
 			"selectors at: (instName, ':') put: i"]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCAbstractRow >> columns [
 	"Answer an <Array> of <ODBCColAttr>s describing the columns in this row."
 
 	^ columns
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCAbstractRow >> columns: anArrayOfODBCColAttr [
 
 	columns := anArrayOfODBCColAttr
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCAbstractRow >> contents [
 
 	^ contents
 ]
 
-{ #category : #exceptions }
+{ #category : 'exceptions' }
 ODBCAbstractRow >> doesNotUnderstand: aMessage [
 	"Private - See if the message selector is one of the field names of the receiver.
 	If so, access that field."
@@ -144,14 +146,14 @@ ODBCAbstractRow >> doesNotUnderstand: aMessage [
 		ifFalse: [self at: selector ifAbsent: [super doesNotUnderstand: aMessage]]
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 ODBCAbstractRow >> hash [
 	"Answer the <integer> hash value for the receiver."
 
 	^ self contents hash
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 ODBCAbstractRow >> isDeletedRow [
 	"Answer whether the receiver represents a row in a result set which has been
 	deleted in the time since the result set was originally queried."
@@ -159,7 +161,7 @@ ODBCAbstractRow >> isDeletedRow [
 	^ self status = SQL_ROW_DELETED
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 ODBCAbstractRow >> printOn: aStream [
 	"Append the ASCII representation of the receiver to aStream."
 
@@ -171,7 +173,7 @@ ODBCAbstractRow >> printOn: aStream [
 	aStream nextPut: $)
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCAbstractRow >> selectors [
 	"Private - Answer a <LookupTable> mapping the names of fields in the receiver to
 	column indices."
@@ -180,7 +182,7 @@ ODBCAbstractRow >> selectors [
 	^ selectors
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCAbstractRow >> status [
 
 	^ status

--- a/src/ODBC-Core/ODBCAbstractStatement.class.st
+++ b/src/ODBC-Core/ODBCAbstractStatement.class.st
@@ -10,8 +10,8 @@ Instance Variables:
 Based on DBAbstractStatement from Dolphin Smalltalk Database Connection package.
 "
 Class {
-	#name : #ODBCAbstractStatement,
-	#superclass : #Object,
+	#name : 'ODBCAbstractStatement',
+	#superclass : 'Object',
 	#instVars : [
 		'handle',
 		'parent',
@@ -25,10 +25,12 @@ Class {
 		'ODBCConstants',
 		'ODBCRetCodes'
 	],
-	#category : #'ODBC-Core-Base'
+	#category : 'ODBC-Core-Base',
+	#package : 'ODBC-Core',
+	#tag : 'Base'
 }
 
-{ #category : #'class initialization' }
+{ #category : 'class initialization' }
 ODBCAbstractStatement class >> initialize [
 	"
 		self initialize
@@ -42,20 +44,20 @@ ODBCAbstractStatement class >> initialize [
 		at: #dynamic put: SQL_CURSOR_DYNAMIC
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 ODBCAbstractStatement class >> isAbstract [
 
 	^self == ODBCAbstractStatement
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 ODBCAbstractStatement class >> new [
 	"Private - Should not implement. Use #parent:"
 
 	^self shouldNotImplement
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 ODBCAbstractStatement class >> parent: anODBCConnection [
 	"Answer an initialized instance of the receiver."
 
@@ -64,7 +66,7 @@ ODBCAbstractStatement class >> parent: anODBCConnection [
 		yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 ODBCAbstractStatement class >> parent: anODBCConnection cursorType: aSymbol [
 	"Answer an initialized instance of the receiver."
 
@@ -73,7 +75,7 @@ ODBCAbstractStatement class >> parent: anODBCConnection cursorType: aSymbol [
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCAbstractStatement >> allocatedHandle [
 	"Private - Answer the receiver's ODBC statement handle, which is lazily
 	allocated if necessary."
@@ -86,7 +88,7 @@ ODBCAbstractStatement >> allocatedHandle [
 	^ handle
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCAbstractStatement >> asParameter [
 	"Answer the receiver in a form suitable for passing to an external function
 	primitive method (see ExternalLibrary and subclasses)."
@@ -94,20 +96,20 @@ ODBCAbstractStatement >> asParameter [
 	^ self executedHandle
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCAbstractStatement >> assignHandle: aSQLHANDLE [
 
 	handle := aSQLHANDLE
 ]
 
-{ #category : #'realizing/unrealizing' }
+{ #category : 'realizing/unrealizing' }
 ODBCAbstractStatement >> basicFree [
 	"Private - Free up all ODBC resources."
 
 	parent freeStmtHandle: self
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 ODBCAbstractStatement >> cancel [
 	"Cancel any outstanding asynchronous request."
 
@@ -118,7 +120,7 @@ ODBCAbstractStatement >> cancel [
 				ifFalse: [self dbCheckException: (ODBCLibrary default sqlCancel: handle) ]]
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 ODBCAbstractStatement >> close [
 	"Private - Close the cursor, but keep the handle.
 	Implementation Note: Use SQLFreeStmt(,SQL_CLOSE), rather than SQLCloseCursor, since the latter
@@ -131,7 +133,7 @@ ODBCAbstractStatement >> close [
 			(ODBCLibrary default sqlFreeStmt: handle option: SQL_CLOSE) ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCAbstractStatement >> columnLength: anInteger [
 	"Answer the length (bytes) of column number anInteger in the Result Set."
 
@@ -150,14 +152,14 @@ ODBCAbstractStatement >> columnLength: anInteger [
 	^ len value
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCAbstractStatement >> cursorType [
 	"Answer the symbolic cursor type name (one of #dynamic, #forwardOnly, #keysetDriven or #static)."
 
 	^ cursorType
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCAbstractStatement >> cursorType: aSymbol [
 
 	(CursorTypes includesKey: aSymbol)
@@ -167,7 +169,7 @@ ODBCAbstractStatement >> cursorType: aSymbol [
 	handle isNull ifFalse: [self setCursorType]
 ]
 
-{ #category : #exceptions }
+{ #category : 'exceptions' }
 ODBCAbstractStatement >> dbCheckException: anIntegerRetCode [
 	"Private - Checks anIntegerRetCode to see if an ODBCError or ODBCWarning should be 	signalled"
 
@@ -180,7 +182,7 @@ ODBCAbstractStatement >> dbCheckException: anIntegerRetCode [
 				ifFalse: [ODBCError]) signalWith: (self exceptionDetails: anIntegerRetCode)]
 ]
 
-{ #category : #constants }
+{ #category : 'constants' }
 ODBCAbstractStatement >> defaultCursorType [
 	"Answer the <Symbol>ic name of the default cursor type to be used for statements
 	(one of #dynamic, #forwardOnly, #keysetDriven, #static)."
@@ -188,7 +190,7 @@ ODBCAbstractStatement >> defaultCursorType [
 	^ self subclassResponsibility
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCAbstractStatement >> describeCol: anInteger [
 	"Answer an ODBCColAttr object which describes the column with the specified
 	<integer> index in the receiver's result set."
@@ -196,7 +198,7 @@ ODBCAbstractStatement >> describeCol: anInteger [
 	^ (self describeCols: (Array with: anInteger)) first
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCAbstractStatement >> describeCols: columnNumbers [
 	"Answer an array of <ODBCColAttr>s describing each of the columns of the receiver's results with indices in the <sequencedReadableCollection> argument."
 
@@ -263,7 +265,7 @@ ODBCAbstractStatement >> describeCols: columnNumbers [
 	^ answer
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCAbstractStatement >> driverHStmt [
 	"Private - Answer the handle to the driver statement"
 
@@ -278,7 +280,7 @@ ODBCAbstractStatement >> driverHStmt [
 	^ value
 ]
 
-{ #category : #exceptions }
+{ #category : 'exceptions' }
 ODBCAbstractStatement >> exceptionDetails: anIntegerRetCode [
 	"Private - Answer an ODBCExceptionDetails instance that describes the state of the
 	receiver following an exception. This will be available as the tag of a subsequent
@@ -289,7 +291,7 @@ ODBCAbstractStatement >> exceptionDetails: anIntegerRetCode [
 			yourself
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 ODBCAbstractStatement >> exec [
 	"Private - Execute the tables query the receiver represents."
 
@@ -297,7 +299,7 @@ ODBCAbstractStatement >> exec [
 	executed := true
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 ODBCAbstractStatement >> executeStatement [
 	"Private - Execute the database command that the receiver represents.
 	Answer the <integer> return code."
@@ -305,7 +307,7 @@ ODBCAbstractStatement >> executeStatement [
 	^ self subclassResponsibility
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCAbstractStatement >> executedHandle [
 	"Private - Answer the receiver's ODBC statement handle having lazily
 	executed the SQL statement associated with the receiver."
@@ -316,14 +318,14 @@ ODBCAbstractStatement >> executedHandle [
 	^ answer
 ]
 
-{ #category : #finalization }
+{ #category : 'finalization' }
 ODBCAbstractStatement >> finalizationRegistry [
 	"Use the parent's statements WeakRegistry"
 
 	^ parent statements
 ]
 
-{ #category : #finalization }
+{ #category : 'finalization' }
 ODBCAbstractStatement >> finalize [
 	"Private - Free any external resources held by the receiver.
 	Should any error occur we print it to trace but otherwise ignore it."
@@ -331,14 +333,14 @@ ODBCAbstractStatement >> finalize [
 	[ self free ] on: ODBCError do: [:e | e trace ]
 ]
 
-{ #category : #'realizing/unrealizing' }
+{ #category : 'realizing/unrealizing' }
 ODBCAbstractStatement >> free [
 	"Free up all resources leaving the receiver in a re-usable state."
 
 	handle isNull ifFalse: [[ self basicFree ] ensure: [ self reset ]]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCAbstractStatement >> getStringAttribute: anInteger [
 	"Private - Answer a <String> containing the value of the statement attribute identified by the <integer> argument."
 
@@ -355,13 +357,13 @@ ODBCAbstractStatement >> getStringAttribute: anInteger [
 	self stringEncoder decodeNullTerminatedStringFrom: buffer] ensure: [ buffer free ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCAbstractStatement >> handle [
 
 	^ handle
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ODBCAbstractStatement >> initialize [
 	"Private - Initialize a new instance of the receiver."
 
@@ -369,7 +371,7 @@ ODBCAbstractStatement >> initialize [
 	cursorType := self defaultCursorType
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ODBCAbstractStatement >> initialize: anODBCConnection [
 	"Private - Initialize the receiver as a new statement of the
 	<ODBCConnection>, anODBCConnection."
@@ -378,7 +380,7 @@ ODBCAbstractStatement >> initialize: anODBCConnection [
 	self initialize
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCAbstractStatement >> moveTo: anIntegerRow [
 	"Private - Position the cursor at the specified
 	row so that it is read on a subsequent Fetch (requires
@@ -391,7 +393,7 @@ ODBCAbstractStatement >> moveTo: anIntegerRow [
 				lockType: SQL_LOCK_NO_CHANGE)
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCAbstractStatement >> numColumns [
 	"Answer the number of columns in the receiver's result set."
 
@@ -404,7 +406,7 @@ ODBCAbstractStatement >> numColumns [
 	^ ccol value
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCAbstractStatement >> numRows [
 	"Answer the number of rows affected by an UPDATE, DELETE or INSERT command exec'd on
 	the receiver. May also work for some SELECTs, although often the answer will be -1
@@ -418,21 +420,21 @@ ODBCAbstractStatement >> numRows [
 	^ rowCount value
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCAbstractStatement >> parent [
 	"Answer the statement's parent <ODBCConnection> object."
 
 	^ parent
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ODBCAbstractStatement >> reset [
 
 	handle := SQLHANDLE null.
 	executed := false
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCAbstractStatement >> results [
 	"Answer an <ODBCResultSet> that manages the results for the receiver.
 	The result set will cause the receiver to be lazily executed when
@@ -443,7 +445,7 @@ ODBCAbstractStatement >> results [
 			ifFalse: [ODBCResultSet]) statement: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCAbstractStatement >> setAttribute: attributeInteger value: anIntegerOrStringOrBytes size: sizeInteger [
 	| ret |
 	ret := ODBCLibrary default
@@ -454,7 +456,7 @@ ODBCAbstractStatement >> setAttribute: attributeInteger value: anIntegerOrString
 	self dbCheckException: ret
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 ODBCAbstractStatement >> setCursorType [
 	"Private - Set the cursor type of the statement to one of: #static, #dynamic, #keysetDriven or #forwardOnly.
 	See the ODBC documentation for details of the different cursor types."
@@ -465,14 +467,14 @@ ODBCAbstractStatement >> setCursorType [
 			size: SQL_IS_UINTEGER
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ODBCAbstractStatement >> setDefaultAttributes [
 	"Private - Set the default attributes of the statement that need to be set before the statement is prepared."
 
 	self suppressErrorsDo: [ self setCursorType ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCAbstractStatement >> statusArray: anArrayOfWORDs [
 	"Private - Set the argument to be the receiver's status array attribute."
 
@@ -482,13 +484,13 @@ ODBCAbstractStatement >> statusArray: anArrayOfWORDs [
 		size: SQL_IS_POINTER
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCAbstractStatement >> stringEncoder [
 
 	^ODBCConnection stringEncoder
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCAbstractStatement >> suppressErrorsDo: aNiladicBlock [
 
 	aNiladicBlock on: ODBCError do: [:e | e trace]

--- a/src/ODBC-Core/ODBCBoundBuffer.class.st
+++ b/src/ODBC-Core/ODBCBoundBuffer.class.st
@@ -8,16 +8,18 @@ Based on DBBoundRow from Dolphin Smalltalk Database Connection package.
 
 "
 Class {
-	#name : #ODBCBoundBuffer,
-	#superclass : #ODBCRowBuffer,
+	#name : 'ODBCBoundBuffer',
+	#superclass : 'ODBCRowBuffer',
 	#pools : [
 		'ODBCCTypes',
 		'ODBCConstants'
 	],
-	#category : #'ODBC-Core-Base'
+	#category : 'ODBC-Core-Base',
+	#package : 'ODBC-Core',
+	#tag : 'Base'
 }
 
-{ #category : #operations }
+{ #category : 'operations' }
 ODBCBoundBuffer >> bind: aDBStatement [
 	"Private - Bind the receiver's field buffers to columns in the result table."
 
@@ -39,7 +41,7 @@ ODBCBoundBuffer >> bind: aDBStatement [
 	^ hStmt
 ]
 
-{ #category : #'data retrieval' }
+{ #category : 'data retrieval' }
 ODBCBoundBuffer >> getData: aDBStatement [
 	"Private - Not currently relevant to a bound row, though it might be if
 	we wanted to use SQLGetData for long values."

--- a/src/ODBC-Core/ODBCColAttr.class.st
+++ b/src/ODBC-Core/ODBCColAttr.class.st
@@ -14,8 +14,8 @@ Based on DBColAttr from Dolphin Smalltalk Database Connection package.
 
 "
 Class {
-	#name : #ODBCColAttr,
-	#superclass : #Object,
+	#name : 'ODBCColAttr',
+	#superclass : 'Object',
 	#instVars : [
 		'columnNumber',
 		'name',
@@ -35,10 +35,12 @@ Class {
 		'ODBCConstants',
 		'ODBCTypes'
 	],
-	#category : #'ODBC-Core-Base'
+	#category : 'ODBC-Core-Base',
+	#package : 'ODBC-Core',
+	#tag : 'Base'
 }
 
-{ #category : #'class initialization' }
+{ #category : 'class initialization' }
 ODBCColAttr class >> initialize [
 	"Private - Initialize the receiver's class variables.
 		self initialize
@@ -81,7 +83,7 @@ ODBCColAttr class >> initialize [
 	self initializeExtraBytes
 ]
 
-{ #category : #'private - initialization' }
+{ #category : 'private - initialization' }
 ODBCColAttr class >> initializeExtraBytes [
 
 	| extraBytes |
@@ -94,13 +96,13 @@ ODBCColAttr class >> initializeExtraBytes [
 	CTypesExtraBytes := extraBytes
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCColAttr >> byteSizeForCharacters: anInteger [
 
 	^ ODBCConnection stringEncoder byteSizeForCharacters: anInteger
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCColAttr >> cType [
 	"Private - Answer the 'C' type to which the described column's values should be converted when loaded
 	into Dolphin buffers (ODBCFields)."
@@ -108,21 +110,21 @@ ODBCColAttr >> cType [
 	^ SQLToCTypes at: sqlType+TypeOffset
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCColAttr >> columnNumber [
 	"Answer the instance variable columnNumber"
 
 	^ columnNumber
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCColAttr >> columnNumber: anInteger [
 	"Private - Set the instance variable columnNumber to anInteger."
 
 	columnNumber := anInteger
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCColAttr >> deleteRuleMask [
 	"Answer the delete rule mask for the receiver"
 
@@ -131,7 +133,7 @@ ODBCColAttr >> deleteRuleMask [
 	^ answer == 0 ifFalse: [ answer bitShift: -1 ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCColAttr >> deleteRuleMask: anInteger [
 	"Private - Set the delete rule mask for the receiver to anInteger"
 
@@ -140,27 +142,27 @@ ODBCColAttr >> deleteRuleMask: anInteger [
 		self specialFlagAt: (1 bitShift: anInteger + 4) put: true ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 ODBCColAttr >> hasVariableTransferOctetLength [
 
 	^ (self isCharType or: [self isBinaryType]) and: [self isFixedPointType not]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ODBCColAttr >> initialize [
 	"Private - Initialize the receiver"
 
 	special := (SQL_PARAM_INPUT bitShift: ParameterTypeShift)
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 ODBCColAttr >> isBinaryType [
 	"Private - Answers true if the receiver represents a character based column"
 
 	^ self cType == SQL_C_BINARY
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 ODBCColAttr >> isCharType [
 	"Private - Answers true if the receiver represents a character based column"
 
@@ -169,83 +171,83 @@ ODBCColAttr >> isCharType [
 	^ (cType := self cType) == SQL_C_CHAR or: [cType == SQL_C_WCHAR]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 ODBCColAttr >> isFixedPointType [
 
 	^ sqlType == SQL_DECIMAL or: [sqlType == SQL_NUMERIC]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 ODBCColAttr >> isForeignKey [
 	"Answer true if the receiver represents a foreign key"
 
 	^ self specialFlagAt: ForeignKey
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCColAttr >> isForeignKey: aBoolean [
 	"Private - Mark the receiver as representing a foreign key according to aBoolean"
 
 	self specialFlagAt: ForeignKey put: aBoolean
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 ODBCColAttr >> isKey [
 	"Answer true if the receiver is a key"
 
 	^ special anyMask: (PrimaryKey bitOr: ForeignKey)
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 ODBCColAttr >> isPrimaryKey [
 	"Answer true if the receiver is a primary key"
 
 	^ self specialFlagAt: PrimaryKey
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCColAttr >> isPrimaryKey: aBoolean [
 	"Private - Sets the receiver to be a primary key according to aBoolean"
 
 	self specialFlagAt: PrimaryKey put: aBoolean
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCColAttr >> length [
 	"Answer the length instance variable."
 
 	^ length
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCColAttr >> length: anInteger [
 	"Private - Set the length instance variable to anInteger."
 
 	length := anInteger
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCColAttr >> lengthC [
 	"Private - Answer the length of ByteArray sufficient to hold an entry for this column when converted to 'C' data. This needs to include any extra space for null-terminators if the 'C' target type is some kind of string."
 
 	^ length + (CTypesExtraBytes at: sqlType+TypeOffset)
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCColAttr >> name [
 	"Answer the name instance variable."
 
 	^ name
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCColAttr >> name: aString [
 	"Private - Set the name instance variable to aString."
 
 	name := aString
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCColAttr >> parameterType [
 	"Answer the SQL_PARAM_XXXX value that defines the type of parameter
 	the receiver represents when used in a parameterized statement. The default
@@ -255,7 +257,7 @@ ODBCColAttr >> parameterType [
 	^ (special bitAnd: ParameterTypeMask) >> ParameterTypeShift
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCColAttr >> parameterType: anInteger [
 	"Set the type of parameter the receiver represents when used in a parameterized
 	statement to the SQL_PARAM_XXXX value specified as the integer argument.
@@ -273,21 +275,21 @@ ODBCColAttr >> parameterType: anInteger [
 						bitOr: (anInteger bitShift: ParameterTypeShift)
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCColAttr >> precision [
 	"Answer the precision instance variable."
 
 	^ precision
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCColAttr >> precision: anInteger [
 	"Private - Set the precision instance variable to anInteger."
 
 	precision := anInteger
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 ODBCColAttr >> printOn: aStream [
 	"Append the ASCII representation of
 	 the receiver to aStream."
@@ -306,28 +308,28 @@ ODBCColAttr >> printOn: aStream [
 		nextPut: $)
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCColAttr >> scale [
 	"Answer the scale instance variable."
 
 	^ scale
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCColAttr >> scale: anInteger [
 	"Private - Set the scale instance variable to anInteger."
 
 	scale := anInteger
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCColAttr >> specialFlagAt: flagMask [
 	"Private - Answer the special flag identified by flagMask"
 
 	^ special allMask: flagMask
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCColAttr >> specialFlagAt: flagMask put: aBoolean [
 	"Private - Set the special flag identified by flagMask to aBoolean"
 
@@ -336,7 +338,7 @@ ODBCColAttr >> specialFlagAt: flagMask put: aBoolean [
 		ifFalse: [ special bitClear: flagMask ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCColAttr >> transferOctetLength [
 	"Private - Return the transfer octet length (size in bytes of the buffer necessary to receive data for this column) based on the column type.
 	https://docs.microsoft.com/en-us/sql/odbc/reference/appendixes/transfer-octet-length"
@@ -361,21 +363,21 @@ ODBCColAttr >> transferOctetLength [
 		ifFalse: [self error: 'unknown type']
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCColAttr >> type [
 	"Answer the sqlType instance variable."
 
 	^ sqlType
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCColAttr >> type: anInteger [
 	"Private - Set the sqlType instance variable to anInteger."
 
 	sqlType := anInteger
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCColAttr >> updateRuleMask [
 	"Answer the update rule mask for the receiver"
 
@@ -384,7 +386,7 @@ ODBCColAttr >> updateRuleMask [
 	^answer == 0 ifFalse: [ answer bitShift: -1 ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCColAttr >> updateRuleMask: anInteger [
 	"Private - Set the update rule mask for the receiver to anInteger"
 

--- a/src/ODBC-Core/ODBCColFlags.class.st
+++ b/src/ODBC-Core/ODBCColFlags.class.st
@@ -2,8 +2,8 @@
 Based on DBColFlags pool dictionary from Dolphin Smalltalk Database Connection package.
 "
 Class {
-	#name : #ODBCColFlags,
-	#superclass : #SharedPool,
+	#name : 'ODBCColFlags',
+	#superclass : 'SharedPool',
 	#classVars : [
 		'DeleteCascade',
 		'DeleteRestrict',
@@ -18,10 +18,12 @@ Class {
 		'UpdateRules',
 		'UpdateSetNull'
 	],
-	#category : #'ODBC-Core-Base'
+	#category : 'ODBC-Core-Base',
+	#package : 'ODBC-Core',
+	#tag : 'Base'
 }
 
-{ #category : #'class initialization' }
+{ #category : 'class initialization' }
 ODBCColFlags class >> initialize [
 
 	self
@@ -39,73 +41,73 @@ ODBCColFlags class >> initialize [
 		initializeUpdateSetNull
 ]
 
-{ #category : #'private - pool initialization' }
+{ #category : 'private - pool initialization' }
 ODBCColFlags class >> initializeDeleteCascade [
 
 	DeleteCascade := 16
 ]
 
-{ #category : #'private - pool initialization' }
+{ #category : 'private - pool initialization' }
 ODBCColFlags class >> initializeDeleteRestrict [
 
 	DeleteRestrict := 32
 ]
 
-{ #category : #'private - pool initialization' }
+{ #category : 'private - pool initialization' }
 ODBCColFlags class >> initializeDeleteRules [
 
 	DeleteRules := 112
 ]
 
-{ #category : #'private - pool initialization' }
+{ #category : 'private - pool initialization' }
 ODBCColFlags class >> initializeDeleteSetNull [
 
 	DeleteSetNull := 64
 ]
 
-{ #category : #'private - pool initialization' }
+{ #category : 'private - pool initialization' }
 ODBCColFlags class >> initializeForeignKey [
 
 	ForeignKey := 2
 ]
 
-{ #category : #'private - pool initialization' }
+{ #category : 'private - pool initialization' }
 ODBCColFlags class >> initializeParameterTypeMask [
 
 	ParameterTypeMask := 14336
 ]
 
-{ #category : #'private - pool initialization' }
+{ #category : 'private - pool initialization' }
 ODBCColFlags class >> initializeParameterTypeShift [
 
 	ParameterTypeShift := 11
 ]
 
-{ #category : #'private - pool initialization' }
+{ #category : 'private - pool initialization' }
 ODBCColFlags class >> initializePrimaryKey [
 
 	PrimaryKey := 1
 ]
 
-{ #category : #'private - pool initialization' }
+{ #category : 'private - pool initialization' }
 ODBCColFlags class >> initializeUpdateCascade [
 
 	UpdateCascade := 256
 ]
 
-{ #category : #'private - pool initialization' }
+{ #category : 'private - pool initialization' }
 ODBCColFlags class >> initializeUpdateRestrict [
 
 	UpdateRestrict := 512
 ]
 
-{ #category : #'private - pool initialization' }
+{ #category : 'private - pool initialization' }
 ODBCColFlags class >> initializeUpdateRules [
 
 	UpdateRules := 1792
 ]
 
-{ #category : #'private - pool initialization' }
+{ #category : 'private - pool initialization' }
 ODBCColFlags class >> initializeUpdateSetNull [
 
 	UpdateSetNull := 1024

--- a/src/ODBC-Core/ODBCColumnsStatement.class.st
+++ b/src/ODBC-Core/ODBCColumnsStatement.class.st
@@ -4,27 +4,29 @@ ODBCPrimaryKeysStatement is a specialized <ODBCSchemaStatement> for querying met
 Based on DBColumnsStatement from Dolphin Smalltalk Database Connection package.
 "
 Class {
-	#name : #ODBCColumnsStatement,
-	#superclass : #ODBCSchemaStatement,
+	#name : 'ODBCColumnsStatement',
+	#superclass : 'ODBCSchemaStatement',
 	#instVars : [
 		'columnName'
 	],
-	#category : #'ODBC-Core-Base'
+	#category : 'ODBC-Core-Base',
+	#package : 'ODBC-Core',
+	#tag : 'Base'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCColumnsStatement >> columnName [
 
 	^ columnName
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCColumnsStatement >> columnName: aString [
 
 	columnName := aString
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 ODBCColumnsStatement >> executeStatement [
 	"Private - Execute the database command that the receiver represents.
 	Answer the <integer> return code."

--- a/src/ODBC-Core/ODBCConnection.class.st
+++ b/src/ODBC-Core/ODBCConnection.class.st
@@ -20,8 +20,8 @@ Class Variables:
 Based on DBConnection from Dolphin Smalltalk Database Connection package.
 "
 Class {
-	#name : #ODBCConnection,
-	#superclass : #Object,
+	#name : 'ODBCConnection',
+	#superclass : 'Object',
 	#instVars : [
 		'handle',
 		'dsn',
@@ -45,10 +45,12 @@ Class {
 		'ODBCConstants',
 		'ODBCRetCodes'
 	],
-	#category : #'ODBC-Core-Base'
+	#category : 'ODBC-Core-Base',
+	#package : 'ODBC-Core',
+	#tag : 'Base'
 }
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 ODBCConnection class >> allocHandle [
 	"Private - Answer a new connection handle."
 
@@ -62,7 +64,7 @@ ODBCConnection class >> allocHandle [
 	^hDBC
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 ODBCConnection class >> connectString: aString do: aTwoArgBlock [
 	"Private - Interpret the connection string and pass the parameter name and value from each
 	$; separated substring to aTwoArgBlock."
@@ -85,14 +87,14 @@ ODBCConnection class >> connectString: aString do: aTwoArgBlock [
 				aTwoArgBlock value: paramName value: paramValue]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCConnection class >> connections [
 	"Answer the <collection> of active connections."
 
 	^ Connections
 ]
 
-{ #category : #exceptions }
+{ #category : 'exceptions' }
 ODBCConnection class >> dbCheckException: anIntegerRetCode [
 	"Private - Checks anIntegerRetCode to see if a ODBCError or ODBCWarning should be signalled"
 
@@ -105,7 +107,7 @@ ODBCConnection class >> dbCheckException: anIntegerRetCode [
 				ifFalse: [ ODBCError ]) signalWith: (self exceptionDetails: anIntegerRetCode)]
 ]
 
-{ #category : #'class initialization' }
+{ #category : 'class initialization' }
 ODBCConnection class >> determineStringEncoder [
 	"The String encoding can vary depending on the ODBC driver manager:
 	Windows - always UTF16
@@ -123,7 +125,7 @@ ODBCConnection class >> determineStringEncoder [
 	(drivers first key at: 2) = Character null ifTrue: [ StringEncoder := ODBCUTF32Encoder new ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCConnection class >> enumerateDataSources [
 	"Answers an array of associations of all the data sources and
 	 their descriptions"
@@ -169,7 +171,7 @@ ODBCConnection class >> enumerateDataSources [
 	^ sources contents
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCConnection class >> enumerateDrivers [
 	"Answers an array of associations of all the drivers and their attributes"
 
@@ -214,7 +216,7 @@ ODBCConnection class >> enumerateDrivers [
 	^ drivers contents
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCConnection class >> environmentHandle [
 	"Private - Answer the environment handle.
 	Create it if we haven't done so already."
@@ -235,7 +237,7 @@ ODBCConnection class >> environmentHandle [
 	^ HEnv
 ]
 
-{ #category : #exceptions }
+{ #category : 'exceptions' }
 ODBCConnection class >> exceptionDetails: retCode [
 	"Private - Answer a <ODBCExceptionDetails> instance that describes the state of the
 	receiver following an exception with the specified <integer> return code. This will
@@ -248,7 +250,7 @@ ODBCConnection class >> exceptionDetails: retCode [
 			yourself
 ]
 
-{ #category : #'realizing/unrealizing' }
+{ #category : 'realizing/unrealizing' }
 ODBCConnection class >> freeAll [
 	"Private - Free all of my instances which are recorded
 	in the handle table.
@@ -261,7 +263,7 @@ ODBCConnection class >> freeAll [
 		freeEnvironment
 ]
 
-{ #category : #'realizing/unrealizing' }
+{ #category : 'realizing/unrealizing' }
 ODBCConnection class >> freeEnvironment [
 
 	| ret |
@@ -271,7 +273,7 @@ ODBCConnection class >> freeEnvironment [
 	HEnv := nil
 ]
 
-{ #category : #'class initialization' }
+{ #category : 'class initialization' }
 ODBCConnection class >> initialize [
 	"Private - Initialize the receiver's class variables"
 
@@ -292,7 +294,7 @@ ODBCConnection class >> initialize [
 	self newConnections
 ]
 
-{ #category : #'class initialization' }
+{ #category : 'class initialization' }
 ODBCConnection class >> initializeStringEncoder [
 
 	self determineStringEncoder.
@@ -301,7 +303,7 @@ ODBCConnection class >> initializeStringEncoder [
 	ODBCColAttr initializeExtraBytes
 ]
 
-{ #category : #'realizing/unrealizing' }
+{ #category : 'realizing/unrealizing' }
 ODBCConnection class >> invalidateHandle: anExternalHandle [
 	"Private - Disconnect and free the specified connection handle.
 	This is used by ODBCConnection class to free a connection handle
@@ -315,14 +317,14 @@ ODBCConnection class >> invalidateHandle: anExternalHandle [
 	ret ~= SQL_SUCCESS ifTrue: [ODBCError signalWith: (self exceptionDetails: ret)]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCConnection class >> newConnections [
 	"Use a WeakRegistry so this can take care of finalization for us"
 
-	Connections := WeakRegistry new
+	Connections := FinalizationRegistry new
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCConnection class >> odbcVersion [
 	<script: 'self odbcVersion inspect'>
 	
@@ -337,14 +339,14 @@ ODBCConnection class >> odbcVersion [
 	^ version value
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCConnection class >> reset [
 
 	HEnv := nil.
 	StringEncoder := nil
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCConnection class >> setDefaultEnvAttrs [
 	| ret |
 	ret := ODBCLibrary default
@@ -356,13 +358,13 @@ ODBCConnection class >> setDefaultEnvAttrs [
 	^ret
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCConnection class >> stringEncoder [
 
 	^ StringEncoder ifNil: [ self initializeStringEncoder. StringEncoder ]
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 ODBCConnection class >> transact: aDBConnection action: anInteger [
 	"Private - Performs the requested transaction action on the specified
 	 connection (which if Null implies that ODBC should commit/rollback
@@ -376,7 +378,7 @@ ODBCConnection class >> transact: aDBConnection action: anInteger [
 	ret ~= SQL_SUCCESS ifTrue: [ODBCError signalWith: (aDBConnection exceptionDetails: ret)]
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 ODBCConnection >> allocStmtHandle: aODBCStatement [
 	"Private - Allocate a new statement handle for the specified object.
 	This may cause a connection to be lazily established (via the handle method)."
@@ -395,7 +397,7 @@ ODBCConnection >> allocStmtHandle: aODBCStatement [
 	self statements add: aODBCStatement
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 ODBCConnection >> asParameter [
 	"Answer the receiver in a form suitable for passing to an external function
 	primitive method (see ExternalLibrary and subclasses)."
@@ -404,7 +406,7 @@ ODBCConnection >> asParameter [
 	^ handle
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 ODBCConnection >> basicConnect [
 	"Private - Connect with the parameters specified earlier.
 	Assumes not already connected."
@@ -422,21 +424,21 @@ ODBCConnection >> basicConnect [
 			ifCurtailed: [ self free ]
 ]
 
-{ #category : #transactions }
+{ #category : 'transactions' }
 ODBCConnection >> beginRWTxn [
 	"Start a read/write transaction on this connection."
 
 	self transaction: (ODBCTxn newRWOn: self)
 ]
 
-{ #category : #transactions }
+{ #category : 'transactions' }
 ODBCConnection >> beginTxn [
 	"Start a read only transaction on this connection"
 
 	self transaction: (ODBCTxn newOn: self)
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 ODBCConnection >> buildConnectString [
 
 	| stream |
@@ -459,14 +461,14 @@ ODBCConnection >> buildConnectString [
 	^stream contents readStream upTo: Character null
 ]
 
-{ #category : #enquiries }
+{ #category : 'enquiries' }
 ODBCConnection >> catalogNameSeparator [
 	"Answer the qualifier name separator"
 
 	^ self getStringInfo: SQL_CATALOG_NAME_SEPARATOR
 ]
 
-{ #category : #enquiries }
+{ #category : 'enquiries' }
 ODBCConnection >> catalogTerm [
 	"Answer the <readableString> name for a 'catalog' in the parlance of the DBMS to which the
 	receiver is connected, e.g. in the case of Access this is 'DATABASE'."
@@ -474,7 +476,7 @@ ODBCConnection >> catalogTerm [
 	^ self getStringInfo: SQL_CATALOG_TERM
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 ODBCConnection >> checkEmptyEnvironment [
 	"Private - If there are no more open connections, free the environment"
 
@@ -484,7 +486,7 @@ ODBCConnection >> checkEmptyEnvironment [
 	HEnv := nil
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 ODBCConnection >> close [
 	"Close a database connection - rollback the current transaction, disconnect,
 	and free connection handle"
@@ -498,7 +500,7 @@ ODBCConnection >> close [
 		checkEmptyEnvironment
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 ODBCConnection >> closeNoFail [
 	"Quietly close connection (frees handle), and if no
 	more open connections, free the environment"
@@ -511,26 +513,26 @@ ODBCConnection >> closeNoFail [
 			self checkEmptyEnvironment ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCConnection >> columnFieldIdentifier [
 
 	^columnFieldIdentifier
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCConnection >> columnFieldIdentifier: anInteger [
 
 	columnFieldIdentifier := anInteger
 ]
 
-{ #category : #enquiries }
+{ #category : 'enquiries' }
 ODBCConnection >> columns: aStringTableName [
 	"Answer a list of columns in the table aStringTableName"
 
 	^self columns: nil qualifier: nil owner: nil table: aStringTableName
 ]
 
-{ #category : #enquiries }
+{ #category : 'enquiries' }
 ODBCConnection >> columns: aStringColumn qualifier: aStringQualifier owner: aStringOwner table: aStringTable [
 	"Answer the list of columns in the table matching the specified search criteria"
 
@@ -558,7 +560,7 @@ ODBCConnection >> columns: aStringColumn qualifier: aStringQualifier owner: aStr
 	^colAttrs
 ]
 
-{ #category : #transactions }
+{ #category : 'transactions' }
 ODBCConnection >> commitTxn [
 	"Commit the receiver's current transaction. Raise an error if there is no outstanding transaction."
 
@@ -566,7 +568,7 @@ ODBCConnection >> commitTxn [
 	transaction := nil
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 ODBCConnection >> connect [
 	"Connect with the parameters specified earlier. Do nothing if already connected.
 	Implementation Note: Connections are normally established lazily when the handle
@@ -575,7 +577,7 @@ ODBCConnection >> connect [
 	handle isNull ifTrue: [self basicConnect]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCConnection >> connectString [
 	"Answer the connect string to use for this connection."
 
@@ -583,7 +585,7 @@ ODBCConnection >> connectString [
 	^connectString
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCConnection >> connectString: aString [
 	"Interpret the connection string and grab any parameters from it which we're interested in
 	i.e. those for which we have a 'set' method."
@@ -598,7 +600,7 @@ ODBCConnection >> connectString: aString [
 	connectString := aString
 ]
 
-{ #category : #enquiries }
+{ #category : 'enquiries' }
 ODBCConnection >> convertFunctions [
 	"Answers an array of the conversion functions available"
 
@@ -608,7 +610,7 @@ ODBCConnection >> convertFunctions [
 		select: [:maskName | (mask bitAnd: (ODBCConstants classPool at: maskName)) ~= 0]
 ]
 
-{ #category : #enquiries }
+{ #category : 'enquiries' }
 ODBCConnection >> cursorCommitBehaviour [
 	"Answer an <integer> from the SQL_CB_XXX enumeration identifying the
 	cursor commit behaviour of this connection."
@@ -616,7 +618,7 @@ ODBCConnection >> cursorCommitBehaviour [
 	^self getSQLUSmallIntInfo: SQL_CURSOR_COMMIT_BEHAVIOR
 ]
 
-{ #category : #enquiries }
+{ #category : 'enquiries' }
 ODBCConnection >> cursorRollbackBehaviour [
 	"Answer an <integer> from the SQL_CB_XXX enumeration identifying the
 	cursor rollback behaviour of this connection."
@@ -624,14 +626,14 @@ ODBCConnection >> cursorRollbackBehaviour [
 	^self getSQLUSmallIntInfo: SQL_CURSOR_ROLLBACK_BEHAVIOR
 ]
 
-{ #category : #enquiries }
+{ #category : 'enquiries' }
 ODBCConnection >> dataSourceName [
 	"Answer the data source name as a <readableString>."
 
 	^self getStringInfo: SQL_DATA_SOURCE_NAME
 ]
 
-{ #category : #enquiries }
+{ #category : 'enquiries' }
 ODBCConnection >> databaseName [
 	"Answer the <readableString> database name, e.g. in the case of an Access database this will
 	be the file name, or in the case of an SQL Server database the name of one of the databases hosted
@@ -640,7 +642,7 @@ ODBCConnection >> databaseName [
 	^self getStringInfo: SQL_DATABASE_NAME
 ]
 
-{ #category : #exceptions }
+{ #category : 'exceptions' }
 ODBCConnection >> dbCheckException: arg1 [
 
 	^ arg1 = SQL_SUCCESS ifFalse: [
@@ -650,21 +652,21 @@ ODBCConnection >> dbCheckException: arg1 [
 			  (self exceptionDetails: arg1) ]
 ]
 
-{ #category : #enquiries }
+{ #category : 'enquiries' }
 ODBCConnection >> dbmsName [
 	"Answers the underlying DBMS name as a <readableString>."
 
 	^self getStringInfo: SQL_DBMS_NAME
 ]
 
-{ #category : #enquiries }
+{ #category : 'enquiries' }
 ODBCConnection >> dbmsVersion [
 	"Answers the underlying DBMS version as a <readableString>"
 
 	^self getStringInfo: SQL_DBMS_VER
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 ODBCConnection >> decodeBitMask: anInteger map: aDictionary [
 	| answer |
 	answer := OrderedCollection new.
@@ -674,7 +676,7 @@ ODBCConnection >> decodeBitMask: anInteger map: aDictionary [
 	^answer
 ]
 
-{ #category : #constants }
+{ #category : 'constants' }
 ODBCConnection >> defaultCursorType [
 	"Answer the <Symbol>ic name of the default cursor type to be used for statements
 	(one of #dynamic, #forwardOnly, #keysetDriven, #static).
@@ -684,19 +686,19 @@ ODBCConnection >> defaultCursorType [
 	^#keysetDriven
 ]
 
-{ #category : #constants }
+{ #category : 'constants' }
 ODBCConnection >> defaultFlags [
 	^DriverCompleteMask
 ]
 
-{ #category : #enquiries }
+{ #category : 'enquiries' }
 ODBCConnection >> defaultTransactionIsolation [
 	"Answer the default transaction isolation."
 
 	^TxnIsolationLevels at: (self getSQLUIntegerInfo: SQL_DEFAULT_TXN_ISOLATION)
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 ODBCConnection >> disconnect [
 	"Private - disconnect without freeing handle. All oustanding
 	statements are free'd (this is necessary because they are
@@ -709,42 +711,42 @@ ODBCConnection >> disconnect [
 		self dbCheckException: ret]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCConnection >> driverHDBC [
 	"Private - Answer the handle to the driver connection"
 
 	^self getHandle: SQL_DRIVER_HDBC
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCConnection >> driverHEnv [
 	"Private - Answer the handle to the driver environment"
 
 	^self getHandle: SQL_DRIVER_HENV
 ]
 
-{ #category : #enquiries }
+{ #category : 'enquiries' }
 ODBCConnection >> driverName [
 	"Answer the driver name"
 
 	^self getStringInfo: SQL_DRIVER_NAME
 ]
 
-{ #category : #enquiries }
+{ #category : 'enquiries' }
 ODBCConnection >> driverVersion [
 	"Answer the driver version"
 
 	^self getStringInfo: SQL_DRIVER_VER
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCConnection >> dsn [
 	"Answer the data set name for the receiver"
 
 	^dsn
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCConnection >> dsn: aString [
 	"Set the data set name to aString."
 
@@ -752,7 +754,7 @@ ODBCConnection >> dsn: aString [
 	dsn := aString
 ]
 
-{ #category : #exceptions }
+{ #category : 'exceptions' }
 ODBCConnection >> exceptionDetails: code [
 	"Private - Answer an <ODBCExceptionDetails> instance that describes the state of the
 	receiver following an exception with the specified <integer> return code. This will
@@ -763,7 +765,7 @@ ODBCConnection >> exceptionDetails: code [
 		yourself
 ]
 
-{ #category : #executing }
+{ #category : 'executing' }
 ODBCConnection >> exec: aString [
 	"Execute the SQL in aString.
 	Answer the <ODBCStatement> used to execute the statement"
@@ -771,7 +773,7 @@ ODBCConnection >> exec: aString [
 	^self exec: aString cursorType: #keysetDriven
 ]
 
-{ #category : #executing }
+{ #category : 'executing' }
 ODBCConnection >> exec: aString cursorType: aSymbol [
 	"Execute the SQL in aString, answering the type of cursor specified by the
 	<Symbol> argument (one of #dynamic, #forwardOnly, #keysetDriven, or
@@ -783,7 +785,7 @@ ODBCConnection >> exec: aString cursorType: aSymbol [
 	^statement
 ]
 
-{ #category : #finalizing }
+{ #category : 'finalizing' }
 ODBCConnection >> finalize [
 	"Private - finalize the affairs of the receiver."
 
@@ -793,7 +795,7 @@ ODBCConnection >> finalize [
 	] on: ODBCError do: [:x | x trace]
 ]
 
-{ #category : #'realizing/unrealizing' }
+{ #category : 'realizing/unrealizing' }
 ODBCConnection >> free [
 	"Private - Free the connection handle."
 
@@ -802,14 +804,14 @@ ODBCConnection >> free [
 		handle invalidateHandle]
 ]
 
-{ #category : #'realizing/unrealizing' }
+{ #category : 'realizing/unrealizing' }
 ODBCConnection >> freeNoFail [
 	"Private - Free the connection handle ignoring any errors."
 
 	^ODBCLibrary default sqlFreeHandle: SQL_HANDLE_DBC handle: handle
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 ODBCConnection >> freeStmtHandle: aDBAbstractStatement [
 	| ret hstmt |
 
@@ -823,7 +825,7 @@ ODBCConnection >> freeStmtHandle: aDBAbstractStatement [
 	hstmt invalidateHandle
 ]
 
-{ #category : #enquiries }
+{ #category : 'enquiries' }
 ODBCConnection >> getBoolInfo: anInteger [
 	"Private - Answer a <Boolean> indicating the receiver's info attribute described by anInteger."
 
@@ -839,7 +841,7 @@ ODBCConnection >> getBoolInfo: anInteger [
 	^(value byteAt: 1) = $Y asciiValue
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCConnection >> getHandle [
 	"Private - Answer the handle instance variable.
 	Allocate it if we haven't done so already."
@@ -852,7 +854,7 @@ ODBCConnection >> getHandle [
 	^handle
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 ODBCConnection >> getHandle: anInteger [
 	| value |
 	value := SQLHANDLE new.
@@ -865,7 +867,7 @@ ODBCConnection >> getHandle: anInteger [
 	^value
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCConnection >> getSQLUIntegerAttribute: anInteger [
 	"Private - Answer an <Integer> containing the 32-bit unsigned integer value of the
 	connection attribute identified by the <integer> argument."
@@ -882,7 +884,7 @@ ODBCConnection >> getSQLUIntegerAttribute: anInteger [
 	^buffer value
 ]
 
-{ #category : #enquiries }
+{ #category : 'enquiries' }
 ODBCConnection >> getSQLUIntegerInfo: anInteger [
 	"Private - Answer an Integer containing the value of the receiver's SQLUINTEGER info attribute described by anInteger."
 
@@ -897,7 +899,7 @@ ODBCConnection >> getSQLUIntegerInfo: anInteger [
 	^value value
 ]
 
-{ #category : #enquiries }
+{ #category : 'enquiries' }
 ODBCConnection >> getSQLUSmallIntInfo: anInteger [
 	"Private - Answer an Integer containing the value of the receiver's SQLUSMALLINT info attribute described by infoCode."
 
@@ -912,7 +914,7 @@ ODBCConnection >> getSQLUSmallIntInfo: anInteger [
 	^value value
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCConnection >> getStringAttribute: anInteger [
 	"Private - Answer a <String> containing the value of the connection attribute identified by the <integer> argument."
 
@@ -929,7 +931,7 @@ ODBCConnection >> getStringAttribute: anInteger [
 	self stringEncoder decodeNullTerminatedStringFrom: buffer] ensure: [ buffer free ]
 ]
 
-{ #category : #enquiries }
+{ #category : 'enquiries' }
 ODBCConnection >> getStringInfo: anInteger [
 	"Private - Answer a String containing the value of the receiver's info attribute described by infoCode."
 
@@ -946,21 +948,21 @@ ODBCConnection >> getStringInfo: anInteger [
 	self stringEncoder decodeStringFrom: value byteCount: len value] ensure: [ value free ]
 ]
 
-{ #category : #enquiries }
+{ #category : 'enquiries' }
 ODBCConnection >> hasAccessibleTables [
 	"Answers whetherthe receiver is connected to a DB which has tables that can be accessed."
 
 	^self getBoolInfo: SQL_ACCESSIBLE_TABLES
 ]
 
-{ #category : #enquiries }
+{ #category : 'enquiries' }
 ODBCConnection >> hasIntegrityEnhancementFacility [
 	"Answer whether the DBMS to which the receiver is connected has integrity enhancement facility support."
 
 	^self getBoolInfo: SQL_INTEGRITY
 ]
 
-{ #category : #enquiries }
+{ #category : 'enquiries' }
 ODBCConnection >> identifierCase [
 	"Answer an <integer> constant from the SQL_IC_XXXX enumeration that indicates the
 	case sensitivity of the DBMS to which the receiver is connected."
@@ -968,14 +970,14 @@ ODBCConnection >> identifierCase [
 	^self getSQLUSmallIntInfo: SQL_IDENTIFIER_CASE
 ]
 
-{ #category : #enquiries }
+{ #category : 'enquiries' }
 ODBCConnection >> identifierQuoteCharacter [
 	"Answers the <Character> used to quote identifiers in the DBMS' SQL dialect."
 
 	^(self getStringInfo: SQL_IDENTIFIER_QUOTE_CHAR) first
 ]
 
-{ #category : #enquiries }
+{ #category : 'enquiries' }
 ODBCConnection >> indicesOf: aString [
 	"Answer the a <collection> of <DBRows> being details of all the indices for the
 	table with the specified <readableString> name."
@@ -986,7 +988,7 @@ ODBCConnection >> indicesOf: aString [
 		accurate: true
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ODBCConnection >> initialize [
 	"Private - Initialize the receiver."
 
@@ -996,13 +998,13 @@ ODBCConnection >> initialize [
 	self initializeStatements
 ]
 
-{ #category : #'private - initialization' }
+{ #category : 'private - initialization' }
 ODBCConnection >> initializeStatements [
 	"Use WeakRegistry so this can take care of finalization for us"
-	statements := WeakRegistry new
+	statements := FinalizationRegistry new
 ]
 
-{ #category : #'realizing/unrealizing' }
+{ #category : 'realizing/unrealizing' }
 ODBCConnection >> invalidateAllStmts [
 	"Private - Free all statements under this connection"
 
@@ -1010,14 +1012,14 @@ ODBCConnection >> invalidateAllStmts [
 	self statements finalizeValues
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCConnection >> isReadOnly [
 	"Answer whether the receiver's access mode option is set to read-only."
 
 	^(self getSQLUIntegerAttribute: SQL_ATTR_ACCESS_MODE) = SQL_MODE_READ_ONLY
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCConnection >> isReadOnly: aBoolean [
 	"Set whether the receiver's access mode option is read-only."
 
@@ -1027,28 +1029,28 @@ ODBCConnection >> isReadOnly: aBoolean [
 		size: SQL_IS_UINTEGER
 ]
 
-{ #category : #enquiries }
+{ #category : 'enquiries' }
 ODBCConnection >> isSAGCompliant [
 	"Answer whether the DBMS to which the receiver is connected is SAG compliant."
 
 	^(self getSQLUSmallIntInfo: SQL_ODBC_SAG_CLI_CONFORMANCE) = SQL_OSCC_COMPLIANT
 ]
 
-{ #category : #enquiries }
+{ #category : 'enquiries' }
 ODBCConnection >> isSourceReadOnly [
 	"Answer whether the data source is read only."
 
 	^self getBoolInfo: SQL_DATA_SOURCE_READ_ONLY
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 ODBCConnection >> isTracing [
 	"Answer whether the receiver's trace option is set."
 
 	^(self getSQLUIntegerAttribute: SQL_ATTR_TRACE) = SQL_OPT_TRACE_ON
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCConnection >> isTracing: aBoolean [
 	"Set whether the receiver's trace facility is on or off."
 
@@ -1058,21 +1060,21 @@ ODBCConnection >> isTracing: aBoolean [
 		size: SQL_IS_UINTEGER
 ]
 
-{ #category : #enquiries }
+{ #category : 'enquiries' }
 ODBCConnection >> isTransactionCapable [
 	"Answer whether the DBMS to which the receiver is connected supports transactions."
 
 	^self getSQLUSmallIntInfo: SQL_TXN_CAPABLE
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCConnection >> loginTimeout [
 	"Answer the Integer value of the receiver's login timeout option."
 
 	^self getSQLUIntegerAttribute: SQL_ATTR_LOGIN_TIMEOUT
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCConnection >> loginTimeout: anInteger [
 	"Set the receiver's login timeout to anInteger."
 
@@ -1082,70 +1084,70 @@ ODBCConnection >> loginTimeout: anInteger [
 		size: SQL_IS_UINTEGER
 ]
 
-{ #category : #enquiries }
+{ #category : 'enquiries' }
 ODBCConnection >> maxCatalogNameLength [
 	"Answer the <integer> maximum length of a catalog in the DBMS to which the receiver is connected."
 
 	^self getSQLUSmallIntInfo: SQL_MAX_CATALOG_NAME_LEN
 ]
 
-{ #category : #enquiries }
+{ #category : 'enquiries' }
 ODBCConnection >> maxColumnNameLength [
 	"Answer the <integer> maximum length of a column in the DBMS to which the receiver is connected."
 
 	^self getSQLUSmallIntInfo: SQL_MAX_COLUMN_NAME_LEN
 ]
 
-{ #category : #enquiries }
+{ #category : 'enquiries' }
 ODBCConnection >> maxConnections [
 	"Answer the <integer> maximum number of concurrent connections supported by the DBMS."
 
 	^self getSQLUSmallIntInfo: SQL_MAX_DRIVER_CONNECTIONS
 ]
 
-{ #category : #enquiries }
+{ #category : 'enquiries' }
 ODBCConnection >> maxCursorNameLength [
 	"Answer the <integer> maximum length of a cursor in the DBMS to which the receiver is connected."
 
 	^self getSQLUSmallIntInfo: SQL_MAX_CURSOR_NAME_LEN
 ]
 
-{ #category : #enquiries }
+{ #category : 'enquiries' }
 ODBCConnection >> maxProcedureNameLength [
 	"Answer the <integer> maximum length of a procedure in the DBMS to which the receiver is connected."
 
 	^self getSQLUSmallIntInfo: SQL_MAX_PROCEDURE_NAME_LEN
 ]
 
-{ #category : #enquiries }
+{ #category : 'enquiries' }
 ODBCConnection >> maxSchemaNameLength [
 	"Answer the <integer> maximum length of a schema name in the DBMS to which the receiver is connected."
 
 	^self getSQLUSmallIntInfo: SQL_MAX_SCHEMA_NAME_LEN
 ]
 
-{ #category : #enquiries }
+{ #category : 'enquiries' }
 ODBCConnection >> maxStatements [
 	"Answer the the maximum number of concurrent statements supported."
 
 	^self getSQLUSmallIntInfo: SQL_MAX_CONCURRENT_ACTIVITIES
 ]
 
-{ #category : #enquiries }
+{ #category : 'enquiries' }
 ODBCConnection >> maxTableNameLength [
 	"Answer the maximum length of a table name"
 
 	^self getSQLUSmallIntInfo: SQL_MAX_TABLE_NAME_LEN
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 ODBCConnection >> newParameterizedStatement: aSymbol [
 	"Private - Answer an ODBCParameterizedStatement connected to the receiver"
 
 	^ODBCParameterizedStatement parent: self cursorType: aSymbol
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 ODBCConnection >> newStatement: aSymbol [
 	"Private - Answer an ODBCStatement connected to the receiver and with the specified
 	cursor type."
@@ -1153,7 +1155,7 @@ ODBCConnection >> newStatement: aSymbol [
 	^ ODBCStatement parent: self cursorType: aSymbol
 ]
 
-{ #category : #enquiries }
+{ #category : 'enquiries' }
 ODBCConnection >> numericFunctions [
 	"Answers an array of the numeric functions available"
 
@@ -1163,7 +1165,7 @@ ODBCConnection >> numericFunctions [
 		select: [:maskName | (mask bitAnd: (ODBCConstants bindingOf: maskName) value) ~= 0]
 ]
 
-{ #category : #enquiries }
+{ #category : 'enquiries' }
 ODBCConnection >> odbcConformance [
 	"Answer the level of ODBC conformance:
 		0	- none
@@ -1174,7 +1176,7 @@ ODBCConnection >> odbcConformance [
 	^self getSQLUSmallIntInfo: SQL_ODBC_API_CONFORMANCE
 ]
 
-{ #category : #enquiries }
+{ #category : 'enquiries' }
 ODBCConnection >> odbcSQLConformance [
 	"Answer the level of ODBC SQL conformance:
 		0 - core
@@ -1185,14 +1187,14 @@ ODBCConnection >> odbcSQLConformance [
 	^self getSQLUSmallIntInfo: SQL_ODBC_SQL_CONFORMANCE
 ]
 
-{ #category : #enquiries }
+{ #category : 'enquiries' }
 ODBCConnection >> odbcVersion [
 	"Answer the ODBC version"
 
 	^self getStringInfo: SQL_ODBC_VER
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 ODBCConnection >> open [
 
 	| tmp2 tmp3 tmp4 |
@@ -1222,7 +1224,7 @@ ODBCConnection >> open [
 			 characterCount: (tmp4 value min: tmp2))
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 ODBCConnection >> postCopy [
 	"Apply any final flourish to the copy that may be required in order to ensure that the copy
 	does not share any state with the original, apart from the elements. Answer the receiver. In
@@ -1236,7 +1238,7 @@ ODBCConnection >> postCopy [
 	^self
 ]
 
-{ #category : #executing }
+{ #category : 'executing' }
 ODBCConnection >> prepare: aString [
 	"Prepare the SQL in aString.
 	Answer a new ODBCParameterizedStatement which is used to execute the SQL."
@@ -1244,7 +1246,7 @@ ODBCConnection >> prepare: aString [
 	^self prepare: aString cursorType: self defaultCursorType
 ]
 
-{ #category : #executing }
+{ #category : 'executing' }
 ODBCConnection >> prepare: aString cursorType: aSymbol [
 	"Prepare the SQL in the <readableString> argument, aString, into a new <ODBCParameterizedStatement>
 	with the specified cursor type."
@@ -1255,7 +1257,7 @@ ODBCConnection >> prepare: aString cursorType: aSymbol [
 	^statement
 ]
 
-{ #category : #enquiries }
+{ #category : 'enquiries' }
 ODBCConnection >> primaryKeysOf: aString [
 	"Answer a list of the primary key column names in the
 	table named aString"
@@ -1269,7 +1271,7 @@ ODBCConnection >> primaryKeysOf: aString [
 	^answer
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 ODBCConnection >> printOn: aStream [
 	"Append the ASCII representation of the receiver
 	 to aStream."
@@ -1280,7 +1282,7 @@ ODBCConnection >> printOn: aStream [
 	aStream nextPut: $)
 ]
 
-{ #category : #enquiries }
+{ #category : 'enquiries' }
 ODBCConnection >> procedure: aStringQual owner: aStringOwner name: aStringName [
 	"Answer a list of procedures in the table(s) matching
 	the specified criteria"
@@ -1296,7 +1298,7 @@ ODBCConnection >> procedure: aStringQual owner: aStringOwner name: aStringName [
 	^answer
 ]
 
-{ #category : #enquiries }
+{ #category : 'enquiries' }
 ODBCConnection >> procedureTerm [
 	"Answer the <readableString> name for a 'stored-procedure' in the parlance of the DBMS to which the
 	receiver is connected, e.g. in the case of Access this is 'QUERY'."
@@ -1304,7 +1306,7 @@ ODBCConnection >> procedureTerm [
 	^self getStringInfo: SQL_PROCEDURE_TERM
 ]
 
-{ #category : #enquiries }
+{ #category : 'enquiries' }
 ODBCConnection >> procedures [
 	"Answer a <collection> of the <readableString> names of all the stored procedures in
 	the database."
@@ -1312,14 +1314,14 @@ ODBCConnection >> procedures [
 	^self procedure: nil owner: nil name: nil
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCConnection >> pwd [
 	"Answer the password for the receiver"
 
 	^pwd
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCConnection >> pwd: aString [
 	"Set the password for the receiver to aString"
 
@@ -1327,7 +1329,7 @@ ODBCConnection >> pwd: aString [
 	pwd := aString
 ]
 
-{ #category : #executing }
+{ #category : 'executing' }
 ODBCConnection >> query: aString [
 	"Execute the SQL in aString.
 	Answer an <ODBCResultSet> representing the resultant result set."
@@ -1335,12 +1337,12 @@ ODBCConnection >> query: aString [
 	^self query: aString cursorType: self defaultCursorType
 ]
 
-{ #category : #executing }
+{ #category : 'executing' }
 ODBCConnection >> query: aString cursorType: aSymbol [
 	^(self exec: aString cursorType: aSymbol) results
 ]
 
-{ #category : #executing }
+{ #category : 'executing' }
 ODBCConnection >> query: aString forwardOnly: aBoolean [
 	"Execute the SQL in aString.
 	Answer an <ODBCResultSet> representing the results.
@@ -1353,7 +1355,7 @@ ODBCConnection >> query: aString forwardOnly: aBoolean [
 		cursorType: (aBoolean ifTrue: [#forwardOnly] ifFalse: [#keysetDriven])
 ]
 
-{ #category : #enquiries }
+{ #category : 'enquiries' }
 ODBCConnection >> queryForeignKeysOf: aTableNameString [
 	"Private - Answer the DBResultSet for the standard query SQLForeignKeys()
 	where szFkTableName is set to aTableNameString."
@@ -1366,7 +1368,7 @@ ODBCConnection >> queryForeignKeysOf: aTableNameString [
 	^answer
 ]
 
-{ #category : #transactions }
+{ #category : 'transactions' }
 ODBCConnection >> rollbackTxn [
 	"Rollback the receiver's transaction. Raise an error if there is no outstanding transaction."
 
@@ -1374,7 +1376,7 @@ ODBCConnection >> rollbackTxn [
 	transaction := nil
 ]
 
-{ #category : #enquiries }
+{ #category : 'enquiries' }
 ODBCConnection >> rowIdColumns: aString [
 	"Answer the names of the columns constituting the 'best row ID' in the
 	table named by the <String> argument."
@@ -1388,7 +1390,7 @@ ODBCConnection >> rowIdColumns: aString [
 		nullable: true	"Transaction"
 ]
 
-{ #category : #enquiries }
+{ #category : 'enquiries' }
 ODBCConnection >> rowVersionColumns: aStringTableName [
 	"Answer the names of the columns (if any) in the named table which are updated automatically
 	by the datasource when a row is updated by any transaction (e.g. a timestamp)."
@@ -1402,7 +1404,7 @@ ODBCConnection >> rowVersionColumns: aStringTableName [
 		nullable: true	"Transaction"
 ]
 
-{ #category : #enquiries }
+{ #category : 'enquiries' }
 ODBCConnection >> schemaTerm [
 	"Answer the <readableString> name for a 'schema' in the parlance of the DBMS to which the
 	receiver is connected."
@@ -1410,21 +1412,21 @@ ODBCConnection >> schemaTerm [
 	^self getStringInfo: SQL_SCHEMA_TERM
 ]
 
-{ #category : #enquiries }
+{ #category : 'enquiries' }
 ODBCConnection >> searchPatternEscape [
 	"Answer the search pattern escape character"
 
 	^self getStringInfo: SQL_SEARCH_PATTERN_ESCAPE
 ]
 
-{ #category : #enquiries }
+{ #category : 'enquiries' }
 ODBCConnection >> serverName [
 	"Answer the server name"
 
 	^self getStringInfo: SQL_SERVER_NAME
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCConnection >> setAttribute: idInteger value: anIntegerOrStringOrBytes size: sizeInteger [
 	"Private - Set the an attribute of the receiver's connection."
 
@@ -1437,7 +1439,7 @@ ODBCConnection >> setAttribute: idInteger value: anIntegerOrStringOrBytes size: 
 	self dbCheckException: ret
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 ODBCConnection >> setDefaultAttributes [
 	"Private - Set the default connection attributes."
 
@@ -1447,7 +1449,7 @@ ODBCConnection >> setDefaultAttributes [
 		size: SQL_IS_UINTEGER
 ]
 
-{ #category : #enquiries }
+{ #category : 'enquiries' }
 ODBCConnection >> specialColumns: anIntegerType qualifier: aStringQual owner: aStringOwner name: aStringName scope: anIntegerScope nullable: aBoolean [
 	"Answer a <collection> of the <readableString> names of special
 	columns matching the specified criteria."
@@ -1467,14 +1469,14 @@ ODBCConnection >> specialColumns: anIntegerType qualifier: aStringQual owner: aS
 	^answer
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCConnection >> statements [
 	"Answer a set of active statements"
 
 	^statements
 ]
 
-{ #category : #enquiries }
+{ #category : 'enquiries' }
 ODBCConnection >> statisticsFor: aString type: anInteger accurate: aBoolean [
 	"Answer a collection of statistics for the table with aString name and anInteger type"
 
@@ -1489,13 +1491,13 @@ ODBCConnection >> statisticsFor: aString type: anInteger accurate: aBoolean [
 	^answer
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCConnection >> stringEncoder [
 
 	^self class stringEncoder
 ]
 
-{ #category : #enquiries }
+{ #category : 'enquiries' }
 ODBCConnection >> stringFunctions [
 	"Answer an array of string functions supported"
 
@@ -1505,7 +1507,7 @@ ODBCConnection >> stringFunctions [
 		select: [:maskName | (mask bitAnd: (ODBCConstants bindingOf: maskName) value) ~= 0]
 ]
 
-{ #category : #enquiries }
+{ #category : 'enquiries' }
 ODBCConnection >> supportedCursorTypes [
 	"Answer a <collection> of <Symbol>s, being the cursor types supported by the database to
 	which the receiver is connected."
@@ -1515,7 +1517,7 @@ ODBCConnection >> supportedCursorTypes [
 	^self decodeBitMask: mask map: ScrollTypes
 ]
 
-{ #category : #enquiries }
+{ #category : 'enquiries' }
 ODBCConnection >> supportedTransactionIsolationLevels [
 	"Answer a <collection> of the <Symbol>ic names of the transaction isolation levels
 	supported by this connection."
@@ -1528,42 +1530,42 @@ ODBCConnection >> supportedTransactionIsolationLevels [
 	^answer
 ]
 
-{ #category : #enquiries }
+{ #category : 'enquiries' }
 ODBCConnection >> supportsExpressionsInOrderBy [
 	"Answers whether the receiver supports expressions in a ORDER BY list"
 
 	^self getBoolInfo: SQL_EXPRESSIONS_IN_ORDERBY
 ]
 
-{ #category : #enquiries }
+{ #category : 'enquiries' }
 ODBCConnection >> supportsMultipleActiveTransactions [
 	"Answer whether multiple active transactions are supported."
 
 	^self getBoolInfo: SQL_MULTIPLE_ACTIVE_TXN
 ]
 
-{ #category : #enquiries }
+{ #category : 'enquiries' }
 ODBCConnection >> supportsMultipleResultSets [
 	"Answer whether multiple result sets are supported."
 
 	^self getBoolInfo: SQL_MULT_RESULT_SETS
 ]
 
-{ #category : #enquiries }
+{ #category : 'enquiries' }
 ODBCConnection >> supportsOuterJoins [
 	"Answer whether the receiver supports outer joins."
 
 	^self getBoolInfo: SQL_OUTER_JOINS
 ]
 
-{ #category : #enquiries }
+{ #category : 'enquiries' }
 ODBCConnection >> supportsRowUpdates [
 	"Answer whether the DBMS to which the receiver is connected supports row updates."
 
 	^self getBoolInfo: SQL_ROW_UPDATES
 ]
 
-{ #category : #enquiries }
+{ #category : 'enquiries' }
 ODBCConnection >> systemFunctions [
 	"Answer an array of system functions supported"
 
@@ -1573,21 +1575,21 @@ ODBCConnection >> systemFunctions [
 		select: [:maskName | (mask bitAnd: (ODBCConstants bindingOf: maskName) value) ~= 0]
 ]
 
-{ #category : #enquiries }
+{ #category : 'enquiries' }
 ODBCConnection >> tableTerm [
 	"Answer the underlying vendor name for a table"
 
 	^self getStringInfo: SQL_TABLE_TERM
 ]
 
-{ #category : #enquiries }
+{ #category : 'enquiries' }
 ODBCConnection >> tables [
 	"Answer a collection of all user tables on the database"
 
 	^self tables: nil owners: nil tables: nil types: '''TABLE'''
 ]
 
-{ #category : #enquiries }
+{ #category : 'enquiries' }
 ODBCConnection >> tables: aStringQualifier owners: aStringOwners tables: aStringTables types: aStringTypes [
 	"Answer a <collection> of the <readableString> names of the tables in
 	the connected data source that match the specified criteria."
@@ -1604,7 +1606,7 @@ ODBCConnection >> tables: aStringQualifier owners: aStringOwners tables: aString
 	^answer
 ]
 
-{ #category : #enquiries }
+{ #category : 'enquiries' }
 ODBCConnection >> timeDateFunctions [
 	"Answer an array of available date and time functions"
 
@@ -1614,14 +1616,14 @@ ODBCConnection >> timeDateFunctions [
 		select: [:maskName | (mask bitAnd: (ODBCConstants bindingOf: maskName) value) ~= 0]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCConnection >> traceFile [
 	"Answer a String containing the value of the receiver's trace file option."
 
 	^self getStringAttribute: SQL_ATTR_TRACEFILE
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCConnection >> traceFile: aString [
 	"Set the receiver's trace facility on, outputting to the trace file specified by aString."
 
@@ -1633,7 +1635,7 @@ ODBCConnection >> traceFile: aString [
 	self isTracing: true
 ]
 
-{ #category : #transactions }
+{ #category : 'transactions' }
 ODBCConnection >> transaction [
 	"Answer the outstanding ODBCTnn. Throw an exception if there isn't one."
 
@@ -1642,7 +1644,7 @@ ODBCConnection >> transaction [
 	^transaction
 ]
 
-{ #category : #transactions }
+{ #category : 'transactions' }
 ODBCConnection >> transaction: anODBCTxn [
 	"Private - Set the receiver's transaction to anODBCTxn. Throw an exception if one exists already."
 
@@ -1652,14 +1654,14 @@ ODBCConnection >> transaction: anODBCTxn [
 	self willAutoCommit: transaction isNil
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCConnection >> transactionIsolation [
 	"Answer the receiver's Transaction Isolation Level."
 
 	^TxnIsolationLevels at: (self getSQLUIntegerAttribute: SQL_ATTR_TXN_ISOLATION)
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCConnection >> transactionIsolation: aSymbol [
 	"Set the receiver's transaction isolation level to that named by the <Symbol> argument
 	(one of #readUncommitted, #readCommitted, #repeatableRead, or #serializable)."
@@ -1670,14 +1672,14 @@ ODBCConnection >> transactionIsolation: aSymbol [
 		size: SQL_IS_UINTEGER
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCConnection >> translate [
 	"Answer an Integer containing the the value of receiver's Translate option."
 
 	^self getSQLUIntegerAttribute: SQL_ATTR_TRANSLATE_OPTION
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCConnection >> translate: anInteger [
 	"Set the receiver's translate option to anInteger."
 
@@ -1687,14 +1689,14 @@ ODBCConnection >> translate: anInteger [
 		size: SQL_IS_UINTEGER
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCConnection >> translationDLL [
 	"Answer a String containing the value of the receiver's translate DLL option."
 
 	^self getStringAttribute: SQL_ATTR_TRANSLATE_LIB
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCConnection >> translationDLL: aString [
 	"Set the receiver's translate DLL option to aString."
 
@@ -1704,14 +1706,14 @@ ODBCConnection >> translationDLL: aString [
 		size: SQL_NTS
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCConnection >> uid [
 	"Answer the user identifier for the receiver"
 
 	^uid
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCConnection >> uid: aString [
 	"Set the user identifier for the receiver to aString."
 
@@ -1719,7 +1721,7 @@ ODBCConnection >> uid: aString [
 	uid := aString
 ]
 
-{ #category : #enquiries }
+{ #category : 'enquiries' }
 ODBCConnection >> uniqueIndicesOf: aString [
 	"Answer the a <collection> of <DBRows> being details of the unique indices for the
 	table with the specified <readableString> name."
@@ -1730,40 +1732,40 @@ ODBCConnection >> uniqueIndicesOf: aString [
 		accurate: true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCConnection >> useDriverCompletion [
 	^flags allMask: DriverCompleteMask
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCConnection >> useDriverCompletion: aBoolean [
 	"Enable/disable the user of the SQL_DRIVER_COMPLETE option when opening this connection."
 
 	flags := (aBoolean ifTrue: [flags bitOr: DriverCompleteMask] ifFalse: [flags bitClear: DriverCompleteMask])
 ]
 
-{ #category : #enquiries }
+{ #category : 'enquiries' }
 ODBCConnection >> userName [
 	"Answer the underlying user name for the receiver"
 
 	^self getStringInfo: SQL_USER_NAME
 ]
 
-{ #category : #enquiries }
+{ #category : 'enquiries' }
 ODBCConnection >> views [
 	"Answer a collection of all user tables on the database"
 
 	^self tables: nil owners: nil tables: nil types: '''VIEW'''
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 ODBCConnection >> willAutoCommit [
 	"Answer whether the receiver's auto commit option is set."
 
 	^(self getSQLUIntegerAttribute: SQL_ATTR_AUTOCOMMIT) = SQL_AUTOCOMMIT_ON
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCConnection >> willAutoCommit: aBoolean [
 	"Set whether the receiver's auto commit option is on or off."
 

--- a/src/ODBC-Core/ODBCError.class.st
+++ b/src/ODBC-Core/ODBCError.class.st
@@ -4,23 +4,25 @@ Instances of ODBCError hold exception information for Database Connection errors
 Based on DBError from Dolphin Smalltalk Database Connection package.
 "
 Class {
-	#name : #ODBCError,
-	#superclass : #Error,
+	#name : 'ODBCError',
+	#superclass : 'Error',
 	#pools : [
 		'ODBCConstants',
 		'ODBCRetCodes'
 	],
-	#category : #'ODBC-Core-Base'
+	#category : 'ODBC-Core-Base',
+	#package : 'ODBC-Core',
+	#tag : 'Base'
 }
 
-{ #category : #signalling }
+{ #category : 'signalling' }
 ODBCError class >> signalWith: anODBCExceptionDetails [
 
 	anODBCExceptionDetails buildErrorInfo.
 	self signal: anODBCExceptionDetails displayString withTag: anODBCExceptionDetails
 ]
 
-{ #category : #signaling }
+{ #category : 'signaling' }
 ODBCError >> signal [
 	"Signal this exception."
 

--- a/src/ODBC-Core/ODBCErrorDetails.class.st
+++ b/src/ODBC-Core/ODBCErrorDetails.class.st
@@ -10,18 +10,20 @@ Instance Variables:
 Based on DBErrorDetails from Dolphin Smalltalk Database Connection package.
 "
 Class {
-	#name : #ODBCErrorDetails,
-	#superclass : #Object,
+	#name : 'ODBCErrorDetails',
+	#superclass : 'Object',
 	#instVars : [
 		'msg',
 		'nativeErr',
 		'sqlState',
 		'origin'
 	],
-	#category : #'ODBC-Core-Base'
+	#category : 'ODBC-Core-Base',
+	#package : 'ODBC-Core',
+	#tag : 'Base'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 ODBCErrorDetails class >> fromSQLError: errorString [
 	"Answer a new instance of the receiver built from the information in the
 	<readableString>, errorString."
@@ -34,7 +36,7 @@ ODBCErrorDetails class >> fromSQLError: errorString [
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCErrorDetails >> messageText [
 	"Answer a text representation of the error of the form:
 		STATE: MSG"
@@ -44,42 +46,42 @@ ODBCErrorDetails >> messageText [
 			ifNotNil: [ sqlState , ': ' ]) , msg
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCErrorDetails >> msg [
 	"Answer the msg instance variable."
 
 	^ msg
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCErrorDetails >> msg: aString [
 	"Private - Set the msg instance variable to aString."
 
 	msg := aString
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCErrorDetails >> nativeErr: aString [
 	"Private - Set the nativeErr instance variable to aString."
 
 	nativeErr := aString
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCErrorDetails >> origin: aString [
 	"Private - Set the origin instance variable to aString."
 
 	origin := aString
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCErrorDetails >> sqlState [
 	"Answer the sqlState instance variable."
 
 	^ sqlState
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCErrorDetails >> sqlState: aString [
 	"Private - Set the sqlState instance variable to aString."
 

--- a/src/ODBC-Core/ODBCExceptionDetails.class.st
+++ b/src/ODBC-Core/ODBCExceptionDetails.class.st
@@ -13,8 +13,8 @@ Depending on the activity in progress at the time of the exception, one or more 
 Based on DBExceptionDetails from Dolphin Smalltalk Database Connection package.
 "
 Class {
-	#name : #ODBCExceptionDetails,
-	#superclass : #Object,
+	#name : 'ODBCExceptionDetails',
+	#superclass : 'Object',
 	#instVars : [
 		'errors',
 		'hEnv',
@@ -27,10 +27,12 @@ Class {
 		'ODBCConstants',
 		'ODBCRetCodes'
 	],
-	#category : #'ODBC-Core-Base'
+	#category : 'ODBC-Core-Base',
+	#package : 'ODBC-Core',
+	#tag : 'Base'
 }
 
-{ #category : #operations }
+{ #category : 'operations' }
 ODBCExceptionDetails >> addErrorDetails: newErrorDetails [
 	"Private - Add a new error details object to my collection."
 
@@ -38,7 +40,7 @@ ODBCExceptionDetails >> addErrorDetails: newErrorDetails [
 	errors addLast: newErrorDetails
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 ODBCExceptionDetails >> buildErrorInfo [
 	"Private - Retrieve all error information available from the ODBC Driver
 	 for my handles, unless none is found in which case
@@ -52,7 +54,7 @@ ODBCExceptionDetails >> buildErrorInfo [
 	errors ifNil: [self retCodeError: code]
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 ODBCExceptionDetails >> buildErrorInfoFrom: anExternalHandle type: anIntegerHandleType [
 	"Private - Retrieve all error information available from the ODBC Driver for <anExternalHandle>, which is of type <anIntegerHandleType>"
 
@@ -91,83 +93,83 @@ ODBCExceptionDetails >> buildErrorInfoFrom: anExternalHandle type: anIntegerHand
 				recNumber := recNumber + 1]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCExceptionDetails >> code [
 	"Answer the code instance variable."
 
 	^ code
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCExceptionDetails >> code: anInteger [
 	"Private - Set the instance variable code to anInteger."
 
 	code := anInteger
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCExceptionDetails >> errors [
 	"Answer the errors instance variable."
 
 	^ errors
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCExceptionDetails >> errors: anOrderedCollection [
 	"Private - Set the errors instance variable to anOrderedCollection."
 
 	errors := anOrderedCollection
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCExceptionDetails >> hDBC [
 	"Answer the hDBC instance variable."
 
 	^ hDBC
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCExceptionDetails >> hDBC: anExternalHandle [
 	"Private - Set the instance variable hDBC to anExternalHandle."
 
 	hDBC := anExternalHandle
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCExceptionDetails >> hEnv [
 	"Answer the hEnv instance variable."
 
 	^ hEnv
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCExceptionDetails >> hEnv: anExternalHandle [
 	"Private - Set the instance variable hEnv to anExternalHandle."
 
 	hEnv := anExternalHandle
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCExceptionDetails >> hStmt [
 	"Answer the hStmt instance variable."
 
 	^hStmt
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCExceptionDetails >> hStmt: anExternalHandle [
 	"Private - Set the instance variable hStmt to anExternalHandle."
 
 	hStmt := anExternalHandle
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ODBCExceptionDetails >> initialize [
 
 	hEnv := hDBC := hStmt := SQLHANDLE null
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 ODBCExceptionDetails >> printOn: aStream [
 	"Print an textual representation of the receiver to aStream"
 
@@ -176,7 +178,7 @@ ODBCExceptionDetails >> printOn: aStream [
 		separatedBy: [ aStream space ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCExceptionDetails >> retCodeError: anInteger [
 	"Private - Add to our collection, a new error whose code is anIteger."
 
@@ -188,13 +190,13 @@ ODBCExceptionDetails >> retCodeError: anInteger [
 			yourself)
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCExceptionDetails >> stringEncoder [
 
 	^ stringEncoder
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCExceptionDetails >> stringEncoder: anObject [
 
 	stringEncoder := anObject

--- a/src/ODBC-Core/ODBCField.class.st
+++ b/src/ODBC-Core/ODBCField.class.st
@@ -15,8 +15,8 @@ Class Variables:
 Based on DBField from Dolphin Smalltalk Database Connection package.
 "
 Class {
-	#name : #ODBCField,
-	#superclass : #Object,
+	#name : 'ODBCField',
+	#superclass : 'Object',
 	#instVars : [
 		'column',
 		'buffer',
@@ -33,10 +33,12 @@ Class {
 		'ODBCRetCodes',
 		'ODBCTypes'
 	],
-	#category : #'ODBC-Core-Base'
+	#category : 'ODBC-Core-Base',
+	#package : 'ODBC-Core',
+	#tag : 'Base'
 }
 
-{ #category : #'class initialization' }
+{ #category : 'class initialization' }
 ODBCField class >> initialize [
 	"Initialize the dictionaries of to/from
 	C Type/Smalltalk object converters.
@@ -104,14 +106,14 @@ ODBCField class >> initialize [
 				yourself)
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 ODBCField class >> new [
 	"Use #newForCol:"
 
 	^ self shouldNotImplement
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 ODBCField class >> newForCol: aDBColAttr [
 	"Answer a new instance of the receiver for the column described by aColAttr."
 
@@ -119,7 +121,7 @@ ODBCField class >> newForCol: aDBColAttr [
 		initializeForColumn: aDBColAttr
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 ODBCField >> = comparand [
 	"Answer whether the receiver and the <Object>, comparand,
 	are considered equivalent."
@@ -128,34 +130,34 @@ ODBCField >> = comparand [
 		column = comparand column and: [self value = comparand value]]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCField >> beNull [
 	"Set the receiver to be a null valued field."
 
 	lengthBuf value: SQL_NULL_DATA
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCField >> bufferSize [
 	"Private - Answer the size of the receiver's buffer."
 
 	^ bufferSize
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCField >> column [
 
 	^ column
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCField >> fieldBuf [
 	"Private - Answer the address of the buffer for passing to the ODBC DLL."
 
 	^ buffer
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCField >> fieldSize [
 	"Private - Answer the 'C' length of the receiver's associated column (the C length includes space for the null
 	terminator if the column is a string)"
@@ -163,7 +165,7 @@ ODBCField >> fieldSize [
 	^ column lengthC
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 ODBCField >> getAnsiString [
 	"Private - Answer a <ByteString> read from the receiver's buffer, i.e. to read from a SQL_C_CHAR, SQL_C_VARCHAR, or SQL_C_LONGVARCHAR buffer."
 
@@ -175,28 +177,28 @@ ODBCField >> getAnsiString [
 	^ result
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 ODBCField >> getBoolean [
 	"Private - Answer a <Boolean> read from the receiver's buffer."
 
 	^ self getByte allMask: 1
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 ODBCField >> getByte [
 	"Private - Answer the receiver's buffer as an unsigned byte."
 
 	^ buffer unsignedByteAt: 1
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 ODBCField >> getByteArray [
 	"Private - Answer a <ByteArray> copied from the receiver's buffer."
 
 	^ buffer copyFrom: 1 to: lengthBuf value
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCField >> getData: aDBStatement [
 	"Private - Retrieve the receiver's associated column data from the ODBC result set
 	following a fetch (into the receiver's buffer)."
@@ -212,7 +214,7 @@ ODBCField >> getData: aDBStatement [
 	aDBStatement dbCheckException: ret
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 ODBCField >> getDate [
 	"Private - Answer an instance of <Date> representing the contents of the receiver.
 	Use the services of the ODBCDATE structure to split the buffer."
@@ -220,28 +222,28 @@ ODBCField >> getDate [
 	^ (ODBCDATE fromHandle: buffer) asDate
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 ODBCField >> getDateAndTime [
 	"Private - Answer an instance of <DateAndTime> representing the same DateAndTime as that stored in the buffer as an ODBCDATE and ODBCTIME."
 
 	^ (ODBCTIMESTAMP fromHandle: buffer) asDateAndTime
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 ODBCField >> getDouble [
 	"Private - Answer a <Float> read from the IEEE 64-bit double precision floating point number in the receiver's buffer."
 
 	^ buffer doubleAt: 1
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 ODBCField >> getFloat [
 	"Private - Answer a <Float> representing the 32-bit IEEE single precision floating point number in the receiver's buffer."
 
 	^ buffer floatAt: 1
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 ODBCField >> getGuid [
 	"Private - Answer a <UUID> read from the receiver's buffer."
 
@@ -251,28 +253,28 @@ ODBCField >> getGuid [
 	^ result
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 ODBCField >> getInt64 [
 	"Private - Answer an <integer> read from the 64-bit signed integer in the receiver's buffer."
 
 	^ buffer signedLongLongAt: 1
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 ODBCField >> getLong [
 	"Private - Answer an <integer> read from the 32-bit signed integer in the receiver's buffer."
 
 	^ buffer signedLongAt: 1
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 ODBCField >> getShort [
 	"Private - Answer an <integer> read from the signed 16-bit value in the receiver's buffer."
 
 	^ buffer signedShortAt: 1
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 ODBCField >> getTime [
 	"Private - Answer an instance of <Time> representing the buffer of the receiver.
 	Use the services of the <ODBCTIME> structure to split the buffer."
@@ -280,21 +282,21 @@ ODBCField >> getTime [
 	^ (ODBCTIME fromHandle: buffer) asTime
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 ODBCField >> getUtf16String [
 	"Private - Answer the receiver's buffer as an appropriate String (ByteString, WideString), i.e. to read from a SQL_C_WCHAR, SQL_C_WVARCHAR, or SQL_C_WLONGVARCHAR buffer."
 
 	^ self stringEncoder decodeStringFrom: buffer byteCount: lengthBuf value
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 ODBCField >> hash [
 	"Answer the <integer> hash value for the receiver. Must be the same for any two DBField's that compare equal."
 
 	^ column hash bitXor: self value hash
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCField >> initializeForColumn: aDBColAttr [
 	"Private - Initialize the receiver to represent a value from
 	the database column described by the <DBColAttr> argument.
@@ -307,21 +309,21 @@ ODBCField >> initializeForColumn: aDBColAttr [
 	^self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 ODBCField >> isNull [
 	"Answer whether the receiver represents a null field."
 
 	^ lengthBuf value == SQL_NULL_DATA
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCField >> lengthBuf [
 	"Private - Answer the address of the length buffer for passing to ODBC"
 
 	^ lengthBuf
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 ODBCField >> numberFromNumeric [
 	"Private - Answer the receiver's contents converted from a
 	string NUMERIC to a <ScaledDecimal> (ODBC converts NUMERIC
@@ -345,7 +347,7 @@ ODBCField >> numberFromNumeric [
 	^ ScaledDecimal newFromNumber: number scale: scale
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 ODBCField >> numberToNumeric: aNumber [
 	"Private - Convert the argument to a 'C' string stored in the receiver for passing to ODBC (probably as a
 	bound parameter) where a NUMERIC is expected."
@@ -355,7 +357,7 @@ ODBCField >> numberToNumeric: aNumber [
 		self setAnsiString: ((aNumber asScaledDecimal: column scale) displayString allButLast: 2)]
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 ODBCField >> printOn: aStream [
 	"Append the ASCII representation of the receiver to aStream."
 
@@ -368,7 +370,7 @@ ODBCField >> printOn: aStream [
 		nextPut: $)
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 ODBCField >> setAnsiString: aString [
 	"Private - Set the receiver's buffer from aString."
 
@@ -384,7 +386,7 @@ ODBCField >> setAnsiString: aString [
 	lengthBuf value: byteCount
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 ODBCField >> setBoolean: aBoolean [
 	"Private - Load the receiver's contents buffer with the <Boolean> argument."
 	
@@ -393,7 +395,7 @@ ODBCField >> setBoolean: aBoolean [
 	lengthBuf value: 1
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 ODBCField >> setByte: aNumber [
 	"Private - Set the receiver's buffer to an unsigned byte representation of the
 	<Number> argument."
@@ -403,7 +405,7 @@ ODBCField >> setByte: aNumber [
 	lengthBuf value: 1
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 ODBCField >> setByteArray: aByteArray [
 	"Private - Set the receiver's buffer from the <ByteArray> argument."
 
@@ -418,7 +420,7 @@ ODBCField >> setByteArray: aByteArray [
 	lengthBuf value: byteCount
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 ODBCField >> setDate: aDate [
 	"Private - Set the receiver's buffer with an <ODBCDATE> object instantiated from
 	the <Date> argument."
@@ -428,7 +430,7 @@ ODBCField >> setDate: aDate [
 	lengthBuf value: ODBCDATE byteSize
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 ODBCField >> setDateAndTime: aDateAndTime [
 	"Private - Set the receiver's buffer with an ODBCTIMESTAMP object instantiated from aDateAndTime."
 
@@ -438,7 +440,7 @@ ODBCField >> setDateAndTime: aDateAndTime [
 	lengthBuf value: ODBCTIMESTAMP byteSize
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 ODBCField >> setDouble: aNumber [
 	"Private - Set the receiver's double buffer with <Float> value of the
 	<Number> argument."
@@ -448,7 +450,7 @@ ODBCField >> setDouble: aNumber [
 	lengthBuf value: 8
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 ODBCField >> setFloat: aNumber [
 	"Private - Set the receiver's float buffer with the <Float> value of the
 	<Number> argument, aNumber."
@@ -458,7 +460,7 @@ ODBCField >> setFloat: aNumber [
 	lengthBuf value: 4
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 ODBCField >> setGuid: aUUID [
 	"Private - Set the receiver's buffer with an <GUID> value."
 
@@ -471,7 +473,7 @@ ODBCField >> setGuid: aUUID [
 	lengthBuf value: 16
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 ODBCField >> setInt64: aNumber [
 	"Private - Set the receiver's buffer to the 64-bit signed integer value of the argument."
 
@@ -480,7 +482,7 @@ ODBCField >> setInt64: aNumber [
 	lengthBuf value: 8
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 ODBCField >> setLong: aNumber [
 	"Private - Set the receiver's buffer to a 32-bit signed integer representation of the <Integer> argument."
 	
@@ -489,7 +491,7 @@ ODBCField >> setLong: aNumber [
 	lengthBuf value: 4
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 ODBCField >> setShort: aNumber [
 	"Private - Set the receiver's buffer to the 16-bit signed integer value of the argument."
 	
@@ -498,7 +500,7 @@ ODBCField >> setShort: aNumber [
 	lengthBuf value: 2
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 ODBCField >> setTime: aTime [
 	"Private - Set the receiver's buffer with an ODBCTIME object instantiated from aTime."
 
@@ -507,7 +509,7 @@ ODBCField >> setTime: aTime [
 	lengthBuf value: ODBCTIME byteSize
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 ODBCField >> setUtf16String: aString [
 	"Private - Set the receiver's buffer from aString."
 
@@ -523,7 +525,7 @@ ODBCField >> setUtf16String: aString [
 	lengthBuf value: byteCount
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCField >> shouldTranslate: anObject class: aClass [
 	"Private - Answer whether the receiver should attempt to translate anObject into its buffer.
 	If anObject isNil then we can set the receiver to be null and answer false.
@@ -536,20 +538,20 @@ ODBCField >> shouldTranslate: anObject class: aClass [
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCField >> size [
 	"Private - Answer the size of the receiver's buffer."
 
 	self error: 'do not use this'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCField >> stringEncoder [
 
 	^ ODBCConnection stringEncoder
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCField >> value [
 	"Answer the contents of the receiver as a suitable
 	Smalltalk object."
@@ -558,7 +560,7 @@ ODBCField >> value [
 		  self perform: (GetSelectors at: column type + TypeOffset) ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCField >> value: anObject [
 	"Set the contents of the receiver's buffer from anObject."
 

--- a/src/ODBC-Core/ODBCForeignKeysStatement.class.st
+++ b/src/ODBC-Core/ODBCForeignKeysStatement.class.st
@@ -2,17 +2,19 @@
 Based on DBForeignKeysStatement from Dolphin Smalltalk Database Connection package.
 "
 Class {
-	#name : #ODBCForeignKeysStatement,
-	#superclass : #ODBCSchemaStatement,
+	#name : 'ODBCForeignKeysStatement',
+	#superclass : 'ODBCSchemaStatement',
 	#instVars : [
 		'foreignCatalogName',
 		'foreignSchemaName',
 		'foreignTableName'
 	],
-	#category : #'ODBC-Core-Base'
+	#category : 'ODBC-Core-Base',
+	#package : 'ODBC-Core',
+	#tag : 'Base'
 }
 
-{ #category : #operations }
+{ #category : 'operations' }
 ODBCForeignKeysStatement >> executeStatement [
 	"Private - Execute the database command that the receiver represents.
 	Answer the <integer> return code."
@@ -33,37 +35,37 @@ ODBCForeignKeysStatement >> executeStatement [
 		nameLength6: SQL_NTS
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCForeignKeysStatement >> foreignCatalogName [
 
 	^ foreignCatalogName
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCForeignKeysStatement >> foreignCatalogName: patternString [
 
 	foreignCatalogName := patternString
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCForeignKeysStatement >> foreignSchemaName [
 
 	^ foreignSchemaName
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCForeignKeysStatement >> foreignSchemaName: patternString [
 
 	foreignSchemaName := patternString
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCForeignKeysStatement >> foreignTableName [
 
 	^ foreignTableName
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCForeignKeysStatement >> foreignTableName: aString [
 
 	foreignTableName := aString

--- a/src/ODBC-Core/ODBCForwardOnlyResultSet.class.st
+++ b/src/ODBC-Core/ODBCForwardOnlyResultSet.class.st
@@ -9,15 +9,17 @@ Instance Variables:
 Based on DBForwardOnlyResultSet from Dolphin Smalltalk Database Connection package.
 "
 Class {
-	#name : #ODBCForwardOnlyResultSet,
-	#superclass : #ODBCResultSet,
+	#name : 'ODBCForwardOnlyResultSet',
+	#superclass : 'ODBCResultSet',
 	#instVars : [
 		'position'
 	],
-	#category : #'ODBC-Core-Base'
+	#category : 'ODBC-Core-Base',
+	#package : 'ODBC-Core',
+	#tag : 'Base'
 }
 
-{ #category : #binding }
+{ #category : 'binding' }
 ODBCForwardOnlyResultSet >> bind: anArrayOfColNums [
 	"Private - Create and bind a buffer to hold the
 	specified columns (or #() for all columns)
@@ -27,7 +29,7 @@ ODBCForwardOnlyResultSet >> bind: anArrayOfColNums [
 	position := 0
 ]
 
-{ #category : #'realizing/unrealizing' }
+{ #category : 'realizing/unrealizing' }
 ODBCForwardOnlyResultSet >> close [
 	"Close the statement which generated the receiver."
 
@@ -35,7 +37,7 @@ ODBCForwardOnlyResultSet >> close [
 	position := 0
 ]
 
-{ #category : #'realizing/unrealizing' }
+{ #category : 'realizing/unrealizing' }
 ODBCForwardOnlyResultSet >> free [
 	"Free the statement which generated the receiver and any other
 	resources associated with the receiver itself."
@@ -44,7 +46,7 @@ ODBCForwardOnlyResultSet >> free [
 	position := 0
 ]
 
-{ #category : #positioning }
+{ #category : 'positioning' }
 ODBCForwardOnlyResultSet >> moveFirst [
 	"Private - If not at the start of the result set, then re-exec the statement."
 
@@ -55,7 +57,7 @@ ODBCForwardOnlyResultSet >> moveFirst [
 			self moveNext]
 ]
 
-{ #category : #positioning }
+{ #category : 'positioning' }
 ODBCForwardOnlyResultSet >> moveLast [
 	"Private - Scroll to the last row of the receiver's result set.
 	Answer the <integer> row status value."
@@ -65,7 +67,7 @@ ODBCForwardOnlyResultSet >> moveLast [
 	^ lastStatus
 ]
 
-{ #category : #positioning }
+{ #category : 'positioning' }
 ODBCForwardOnlyResultSet >> moveNext [
 	"Private - Advance to the next row in the result set."
 
@@ -75,7 +77,7 @@ ODBCForwardOnlyResultSet >> moveNext [
 	^ status
 ]
 
-{ #category : #positioning }
+{ #category : 'positioning' }
 ODBCForwardOnlyResultSet >> movePrevious [
 	"Private - Scroll to the previous row of the receiver's result set.
 	Answer the <integer> row status value."
@@ -83,7 +85,7 @@ ODBCForwardOnlyResultSet >> movePrevious [
 	self moveTo: position - 1
 ]
 
-{ #category : #positioning }
+{ #category : 'positioning' }
 ODBCForwardOnlyResultSet >> moveTo: anInteger [
 	| status |
 	position = anInteger
@@ -95,7 +97,7 @@ ODBCForwardOnlyResultSet >> moveTo: anInteger [
 	^status
 ]
 
-{ #category : #'event handling' }
+{ #category : 'event handling' }
 ODBCForwardOnlyResultSet >> onStartup [
 	"Private - The system is starting. Clear down any invalid external
 	resources so that they are lazily reallocated on demand,etc."
@@ -104,14 +106,14 @@ ODBCForwardOnlyResultSet >> onStartup [
 	position := 0
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 ODBCForwardOnlyResultSet >> requery [
 	"Private - Cause a requery to occur lazily on the next access by closing the result set."
 
 	self close
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 ODBCForwardOnlyResultSet >> reverseDo: operation [
 	"Evaluate the <monadicValuable> argument, operation, against each
 	element of the receiver in reverse order, from end to start.

--- a/src/ODBC-Core/ODBCParameterizedStatement.class.st
+++ b/src/ODBC-Core/ODBCParameterizedStatement.class.st
@@ -12,8 +12,8 @@ Instance Variables:
 Based on DBParameterizedStatement from Dolphin Smalltalk Database Connection package.
 "
 Class {
-	#name : #ODBCParameterizedStatement,
-	#superclass : #ODBCStatement,
+	#name : 'ODBCParameterizedStatement',
+	#superclass : 'ODBCStatement',
 	#instVars : [
 		'values',
 		'parameters',
@@ -23,10 +23,12 @@ Class {
 	#pools : [
 		'ODBCCTypes'
 	],
-	#category : #'ODBC-Core-Base'
+	#category : 'ODBC-Core-Base',
+	#package : 'ODBC-Core',
+	#tag : 'Base'
 }
 
-{ #category : #operations }
+{ #category : 'operations' }
 ODBCParameterizedStatement >> bindParams [
 	"Private - Bind parameter columns for a prepared SQL statement so that when we
 	subsequently fill the buffer fields the statement is ready to exec. Normally only done
@@ -53,7 +55,7 @@ ODBCParameterizedStatement >> bindParams [
 						strLenOrIndPtr: eachField lengthBuf)]
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 ODBCParameterizedStatement >> exec [
 	"(Re)Execute a prepared statement."
 
@@ -66,7 +68,7 @@ ODBCParameterizedStatement >> exec [
 	executed := true
 ]
 
-{ #category : #'realizing/unrealizing' }
+{ #category : 'realizing/unrealizing' }
 ODBCParameterizedStatement >> free [
 	"Release external resources held by the receiver,
 	remaining in a consistent state in order that
@@ -77,21 +79,21 @@ ODBCParameterizedStatement >> free [
 	parameters := nil
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCParameterizedStatement >> paramCols [
 	"Answer the receiver's parameter columns"
 
 	^ paramCols
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCParameterizedStatement >> paramCols: anArrayOfColAttrs [
 	"Set the receiver's parameter columns to anArrayOfColAttrs"
 
 	paramCols := anArrayOfColAttrs asArray
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCParameterizedStatement >> parameters [
 	"Private - Answer the receivers bound parameter fields. On first receipt (usually from
 	#exec) completes lazy evaluation by causing allocation of a statement handle, preparing
@@ -104,7 +106,7 @@ ODBCParameterizedStatement >> parameters [
 			  parameters ]
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 ODBCParameterizedStatement >> prepare [
 	"Private - Prepare the receiver for later execution when the parameter values have
 	been set. N.B. This should only be sent once unless closed in the interm."
@@ -120,7 +122,7 @@ ODBCParameterizedStatement >> prepare [
 	isPrepared := true
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 ODBCParameterizedStatement >> prepare: aString [
 	"Private - Prepare the receiver for later execution when the parameter values have
 	been set."
@@ -128,7 +130,7 @@ ODBCParameterizedStatement >> prepare: aString [
 	self sqlString: aString; prepare
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ODBCParameterizedStatement >> reset [
 	"Private - Initialize the receiver."
 
@@ -137,7 +139,7 @@ ODBCParameterizedStatement >> reset [
 	parameters := nil
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 ODBCParameterizedStatement >> setValues [
 	"Private - Copy object values to the bound fields for the parameters of the prepared SQL
 	statement. On first receipt this will cause the parameter fields to be created and bound 	(via #parameters)."
@@ -146,14 +148,14 @@ ODBCParameterizedStatement >> setValues [
 		(parameters at: i) value: (values at: i)]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCParameterizedStatement >> values [
 	"Answer the array of parameter values."
 
 	^ values
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCParameterizedStatement >> values: anArrayOfValues [
 	"Set the receiver's parameter values prior to a future #exec."
 

--- a/src/ODBC-Core/ODBCPrimaryKeysStatement.class.st
+++ b/src/ODBC-Core/ODBCPrimaryKeysStatement.class.st
@@ -4,12 +4,14 @@ ODBCPrimaryKeysStatement is a specialized <ODBCSchemaStatement> for querying abo
 Based on DBPrimaryKeysStatement from Dolphin Smalltalk Database Connection package.
 "
 Class {
-	#name : #ODBCPrimaryKeysStatement,
-	#superclass : #ODBCSchemaStatement,
-	#category : #'ODBC-Core-Base'
+	#name : 'ODBCPrimaryKeysStatement',
+	#superclass : 'ODBCSchemaStatement',
+	#category : 'ODBC-Core-Base',
+	#package : 'ODBC-Core',
+	#tag : 'Base'
 }
 
-{ #category : #operations }
+{ #category : 'operations' }
 ODBCPrimaryKeysStatement >> executeStatement [
 	"Private - Execute the database command that the receiver represents.
 	Answer the <integer> return code."

--- a/src/ODBC-Core/ODBCProceduresStatement.class.st
+++ b/src/ODBC-Core/ODBCProceduresStatement.class.st
@@ -4,15 +4,17 @@ ODBCProceduresStatement is a specialized <ODBCSchemaStatement> for querying abou
 Based on DBProceduresStatement from Dolphin Smalltalk Database Connection package.
 "
 Class {
-	#name : #ODBCProceduresStatement,
-	#superclass : #ODBCSchemaStatement,
+	#name : 'ODBCProceduresStatement',
+	#superclass : 'ODBCSchemaStatement',
 	#instVars : [
 		'procedureName'
 	],
-	#category : #'ODBC-Core-Base'
+	#category : 'ODBC-Core-Base',
+	#package : 'ODBC-Core',
+	#tag : 'Base'
 }
 
-{ #category : #operations }
+{ #category : 'operations' }
 ODBCProceduresStatement >> executeStatement [
 	"Private - Execute the database command that the receiver represents.
 	Answer the <integer> return code."
@@ -27,13 +29,13 @@ ODBCProceduresStatement >> executeStatement [
 		nameLength3: SQL_NTS
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCProceduresStatement >> procedureName [
 
 	^ procedureName
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCProceduresStatement >> procedureName: aString [
 
 	procedureName := aString

--- a/src/ODBC-Core/ODBCResultSet.class.st
+++ b/src/ODBC-Core/ODBCResultSet.class.st
@@ -11,8 +11,8 @@ Based on DBResultSet from Dolphin Smalltalk Database Connection package.
 
 "
 Class {
-	#name : #ODBCResultSet,
-	#superclass : #SequenceableCollection,
+	#name : 'ODBCResultSet',
+	#superclass : 'SequenceableCollection',
 	#instVars : [
 		'statement',
 		'buffer',
@@ -22,16 +22,18 @@ Class {
 		'ODBCConstants',
 		'ODBCRetCodes'
 	],
-	#category : #'ODBC-Core-Base'
+	#category : 'ODBC-Core-Base',
+	#package : 'ODBC-Core',
+	#tag : 'Base'
 }
 
-{ #category : #'class initialization' }
+{ #category : 'class initialization' }
 ODBCResultSet class >> initialize [
 
 	Smalltalk addToStartUpList: self
 ]
 
-{ #category : #'event handling' }
+{ #category : 'event handling' }
 ODBCResultSet class >> onStartup [
 	"Ensure all the receiver's subinstances are in their 'invalidated' state on startup
 	so that they rebuild their external resource when required rather than attempting
@@ -40,14 +42,14 @@ ODBCResultSet class >> onStartup [
 	self allSubInstancesDo: [:i | i onStartup]
 ]
 
-{ #category : #'system startup' }
+{ #category : 'system startup' }
 ODBCResultSet class >> startUp: isImageStarting [
 	"Private - Ensure that old external resources are cleared so that they will be re-created."
 
 	isImageStarting ifTrue: [self onStartup]
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 ODBCResultSet class >> statement: aDBStatement [
 	"Answer a new instance of DBResultSet for aDBStatement."
 
@@ -56,7 +58,7 @@ ODBCResultSet class >> statement: aDBStatement [
 			yourself
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 ODBCResultSet >> , operand [
 	"Answer a new <sequencedReadableCollection> containing the elements
 	of the receiver in their original order with those of the <sequencedReadableCollection>,
@@ -66,14 +68,14 @@ ODBCResultSet >> , operand [
 	^self asOrderedCollection, operand
 ]
 
-{ #category : #adding }
+{ #category : 'adding' }
 ODBCResultSet >> add: newElement [
 	"ODBCResultSets are not extensible."
 
 	^self shouldNotImplement
 ]
 
-{ #category : #allocating }
+{ #category : 'allocating' }
 ODBCResultSet >> allocBuffer: anArrayOfColNums [
 	"Private - Allocate a buffer in the receiver to hold
 	the specified column numbers in the receiver's
@@ -82,7 +84,7 @@ ODBCResultSet >> allocBuffer: anArrayOfColNums [
 	^buffer := self bufferClass new columns: (self describeCols: anArrayOfColNums)
 ]
 
-{ #category : #'double dispatch' }
+{ #category : 'double dispatch' }
 ODBCResultSet >> appendToStream: puttableStream [
 	"Private - Append the receiver's elements to the argument, puttableStream.
 	Answer the receiver.
@@ -92,7 +94,7 @@ ODBCResultSet >> appendToStream: puttableStream [
 	self do: [:element | puttableStream nextPut: element]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCResultSet >> approxSize [
 	"Private - Answer the approximate size of the receiver."
 
@@ -106,7 +108,7 @@ ODBCResultSet >> approxSize [
 	^rowCount < 0 ifTrue: [50] ifFalse: [rowCount]
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 ODBCResultSet >> asArray [
 	"Answer an <Array> of <ODBCRow>s containing all the rows from the receiver.
 	Implementation Note: Avoid using potentially slow #size."
@@ -117,14 +119,14 @@ ODBCResultSet >> asArray [
 	^stream contents
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCResultSet >> at: anInteger [
 	"Answer the row at index anInteger in the receiver's result set"
 
 	^(self moveTo: anInteger) isNil ifFalse: [buffer asObject]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCResultSet >> at: anInteger ifAbsent: aBlock [
 	"Answer the row in the result set at index anInteger, or if there is no such row,
 	the result of evaluating aBlock"
@@ -135,21 +137,21 @@ ODBCResultSet >> at: anInteger ifAbsent: aBlock [
 		ifFalse: [answer]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCResultSet >> at: index put: newElement [
 	"ODBCResultSets are not updatable."
 
 	^self shouldNotImplement
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCResultSet >> atIndex: anInteger [
   	"Answer the row at index anInteger."
 
 	^self at: anInteger ifAbsent: []
 ]
 
-{ #category : #binding }
+{ #category : 'binding' }
 ODBCResultSet >> bind [
 	"Private - Create and 'bind' (an unbound buffer will not
 	actually do any SQLBindCols, though a bound buffer will)
@@ -158,7 +160,7 @@ ODBCResultSet >> bind [
 	self bind: #()
 ]
 
-{ #category : #binding }
+{ #category : 'binding' }
 ODBCResultSet >> bind: anArrayOfColNums [
 	"Private - Create and bind a buffer to hold the
 	specified columns (or #() for all columns)
@@ -167,7 +169,7 @@ ODBCResultSet >> bind: anArrayOfColNums [
 	(self allocBuffer: anArrayOfColNums) bind: statement
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCResultSet >> buffer: anODBCObjBuf [
 	"Private - Set the receiver's buffer. Mainly used to
 	pre-setup an object buffer, rather than have the
@@ -176,7 +178,7 @@ ODBCResultSet >> buffer: anODBCObjBuf [
 	buffer := anODBCObjBuf
 ]
 
-{ #category : #constants }
+{ #category : 'constants' }
 ODBCResultSet >> bufferClass [
 	"Private - Answer the buffer class to use for ODBCResultSets (e.g. ODBCBoundRow for bound buffers
 	where memory is allocated and bound using SQLBindCol, or ODBCUnboundRow for unbound buffers
@@ -185,14 +187,14 @@ ODBCResultSet >> bufferClass [
 	^ODBCBoundBuffer
 ]
 
-{ #category : #'realizing/unrealizing' }
+{ #category : 'realizing/unrealizing' }
 ODBCResultSet >> close [
 	"Close the statement which generated the receiver."
 
 	statement close
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 ODBCResultSet >> collect: transformer [
 	"Evaluate the <monadicValuable> argument, transformer, for each of the
 	receiver's elements in the order defined by the receiver's implementation of #do:.
@@ -209,7 +211,7 @@ ODBCResultSet >> collect: transformer [
 	^answer
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 ODBCResultSet >> copyEmpty: anInteger [
 	"Private - Answer an empty copy of the receiver, with sufficient capacity for anInteger
 	number of elements.
@@ -218,7 +220,7 @@ ODBCResultSet >> copyEmpty: anInteger [
 	^self species new: anInteger
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 ODBCResultSet >> copyFrom: start [
 	"Answer a copy of a subset of the receiver which starts with its element at Integer
 	index start.
@@ -230,7 +232,7 @@ ODBCResultSet >> copyFrom: start [
 	^answer
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 ODBCResultSet >> copySize [
 	"Private - Answer the size of empty copy to create when performing various
 	copying/collecting transformations against the receiver.
@@ -240,7 +242,7 @@ ODBCResultSet >> copySize [
 	^self approxSize
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 ODBCResultSet >> copyWith: newElement [
 	"Answer a <sequencedReadableCollection> which is a copy of
 	the receiver that has newElement concatenated to its end.
@@ -249,7 +251,7 @@ ODBCResultSet >> copyWith: newElement [
 	^self asOrderedCollection addLast: newElement; yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCResultSet >> countElements [
 	"Private - Count, and answer, the number of elements in the receiver."
 
@@ -259,7 +261,7 @@ ODBCResultSet >> countElements [
 	^tally
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 ODBCResultSet >> describeCol: anInteger [
 	"Answer an ODBCColAttr object which describes the column
 	numbered anInteger in the receiver's result set"
@@ -267,7 +269,7 @@ ODBCResultSet >> describeCol: anInteger [
 	^statement describeCol: anInteger
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCResultSet >> describeCols [
 	"Answer the list of column attributes for all of
 	the columns in the receiver's result set"
@@ -275,7 +277,7 @@ ODBCResultSet >> describeCols [
 	^self describeCols: #()
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCResultSet >> describeCols: anArray [
 	"Answer a list of column attributes for the columns in
 	the receiver's result set specified by the column numbers
@@ -293,7 +295,7 @@ ODBCResultSet >> describeCols: anArray [
 	^columns
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 ODBCResultSet >> do: aOneArgBlock [
 
 	| status |
@@ -304,7 +306,7 @@ ODBCResultSet >> do: aOneArgBlock [
 			status := self moveNext]
 ]
 
-{ #category : #positioning }
+{ #category : 'positioning' }
 ODBCResultSet >> fetchScroll: orientationInteger offset: offsetInteger [
 	"Private - Fetch the specified row from the receiver's
 	result set. Answers true if a row was successfully
@@ -325,7 +327,7 @@ ODBCResultSet >> fetchScroll: orientationInteger offset: offsetInteger [
 	^buffer status
 ]
 
-{ #category : #searching }
+{ #category : 'searching' }
 ODBCResultSet >> findLast: discriminator [
 	"Answer the <integer> index of the last element of the receiver for which the
 	<monadicValuable> argument, discriminator, evaluates to true. If there are
@@ -340,14 +342,14 @@ ODBCResultSet >> findLast: discriminator [
 		ifFalse: [super findLast: discriminator]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCResultSet >> first [
 	"Answer the first row of the receiver"
 
 	^self moveFirst isNil ifFalse: [buffer asObject]
 ]
 
-{ #category : #'realizing/unrealizing' }
+{ #category : 'realizing/unrealizing' }
 ODBCResultSet >> free [
 	"Free the statement which generated the receiver and any other
 	resources associated with the receiver itself."
@@ -356,7 +358,7 @@ ODBCResultSet >> free [
 	buffer := nil
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 ODBCResultSet >> from: start keysAndValuesDo: operation [
 	"Evaluate the <dyadicValuable>, operation, for each element of the receiver
 	from the element with <integer> index, start, inclusive. A BoundsError will be
@@ -371,7 +373,7 @@ ODBCResultSet >> from: start keysAndValuesDo: operation [
 			i := i + 1]
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 ODBCResultSet >> from: start to: stop keysAndValuesDo: operation [
 	"Evaluate the <dyadicValuable>, operation, for each element of the receiver
 	between the <integer> indices, start and stop, inclusive with the element and its
@@ -387,7 +389,7 @@ ODBCResultSet >> from: start to: stop keysAndValuesDo: operation [
 			i := i + 1]
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 ODBCResultSet >> hash [
 	"Answer the <integer> hash value for the receiver.
 	Implementation Note: Override to avoid potentially slow #size."
@@ -395,7 +397,7 @@ ODBCResultSet >> hash [
 	^columns hash
 ]
 
-{ #category : #searching }
+{ #category : 'searching' }
 ODBCResultSet >> identityIndexOf: anElement [
 	"Answer the index of the first occurrence of the object which is the argument
 	anElement, within the receiver. If the receiver does not contain anElement,
@@ -404,7 +406,7 @@ ODBCResultSet >> identityIndexOf: anElement [
 	^self findFirst: [:e | anElement == e]
 ]
 
-{ #category : #searching }
+{ #category : 'searching' }
 ODBCResultSet >> indexOf: target [
 	"Answer the <integer> index of the first element of the receiver which is
 	equal to the <Object> argument, target, within the receiver. If the receiver
@@ -414,7 +416,7 @@ ODBCResultSet >> indexOf: target [
 	^self findFirst: [:e | target = e]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 ODBCResultSet >> isEmpty [
 	"Answer true if the receiver collection contains no elements, else answer false."
 
@@ -430,7 +432,7 @@ ODBCResultSet >> isEmpty [
 	^rowCount == 0 or: [rowCount < 0 and: [self first isNil	"Have to retrieve first row"]]
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 ODBCResultSet >> keysAndValuesDo: operation [
 	"Evaluate the <dyadicValuable>, operation, for each element of the receiver
 	with the <integer> index of that element and the element itself as the arguments."
@@ -443,14 +445,14 @@ ODBCResultSet >> keysAndValuesDo: operation [
 	self from: 1 keysAndValuesDo: operation
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCResultSet >> last [
 	"Answer the last row of the receiver's result set"
 
 	^self moveLast isNil ifFalse: [buffer asObject]
 ]
 
-{ #category : #searching }
+{ #category : 'searching' }
 ODBCResultSet >> lastIndexOf: target [
 	"Answer the <integer> index of the last element of the receiver which is
 	equal to the <Object> argument, target, within the receiver. If the receiver
@@ -459,13 +461,13 @@ ODBCResultSet >> lastIndexOf: target [
 	^self findLast: [:e | target = e]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCResultSet >> lookup: keyInteger [
 
 	^self at: keyInteger
 ]
 
-{ #category : #positioning }
+{ #category : 'positioning' }
 ODBCResultSet >> moveFirst [
 	"Private - Scroll to the first row of the receiver's result set.
 	Answer the <integer> row status value."
@@ -473,7 +475,7 @@ ODBCResultSet >> moveFirst [
 	^self fetchScroll: SQL_FETCH_FIRST offset: 0
 ]
 
-{ #category : #positioning }
+{ #category : 'positioning' }
 ODBCResultSet >> moveLast [
 	"Private - Scroll to the last row of the receiver's result set.
 	Answer the <integer> row status value."
@@ -481,7 +483,7 @@ ODBCResultSet >> moveLast [
 	^self fetchScroll: SQL_FETCH_LAST offset: 0
 ]
 
-{ #category : #positioning }
+{ #category : 'positioning' }
 ODBCResultSet >> moveNext [
 	"Private - Scroll to the next row of the receiver's result set.
 	Answer the <integer> row status value."
@@ -489,7 +491,7 @@ ODBCResultSet >> moveNext [
 	^self fetchScroll: SQL_FETCH_NEXT offset: 0
 ]
 
-{ #category : #positioning }
+{ #category : 'positioning' }
 ODBCResultSet >> movePrevious [
 	"Private - Scroll to the previous row of the receiver's result set.
 	Answer the <integer> row status value."
@@ -497,7 +499,7 @@ ODBCResultSet >> movePrevious [
 	^self fetchScroll: SQL_FETCH_PREV offset: 0
 ]
 
-{ #category : #positioning }
+{ #category : 'positioning' }
 ODBCResultSet >> moveTo: anInteger [
 	"Private - Position the cursor at the specified
 	row (requires extended fetch capability),
@@ -508,28 +510,28 @@ ODBCResultSet >> moveTo: anInteger [
 		  ifFalse: [ self scrollTo: anInteger ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCResultSet >> next [
 	"Answer the next row of the receiver's result set, skipping any deleted rows."
 
 	^self moveNext ifNotNil: [buffer asObject]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCResultSet >> numColumns [
 	"Answer the number of columns in the result set associated with the receiver's statement."
 
 	^ statement numColumns
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCResultSet >> numRows [
 	"Answer the number of rows in the result set associated with the receiver's statement."
 
 	^ statement numRows
 ]
 
-{ #category : #'event handling' }
+{ #category : 'event handling' }
 ODBCResultSet >> onStartup [
 	"Private - The system is starting. Clear down any invalid external
 	resources so that they are lazily reallocated on demand."
@@ -537,14 +539,14 @@ ODBCResultSet >> onStartup [
 	buffer := nil
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCResultSet >> previous [
 	"Answer the previous row of the receiver's result set"
 
 	^ self movePrevious ifNotNil: [buffer asObject]
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 ODBCResultSet >> printOn: aStream [
 	"Print a string representation of self onto aStream"
 
@@ -556,7 +558,7 @@ ODBCResultSet >> printOn: aStream [
 		nextPut: $)
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 ODBCResultSet >> rawCollect: aZeroArgBlock [
 	"Private - Answer an OrderedCollection containing the
 	results of evaluating aBlock with the current row
@@ -570,7 +572,7 @@ ODBCResultSet >> rawCollect: aZeroArgBlock [
 	^ answer
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 ODBCResultSet >> rawDo: aZeroArgBlock [
 	"Private - Answer the receiver.  For each row in the
 	receiver's result set evaluates aZeroArgBlock with
@@ -585,21 +587,21 @@ ODBCResultSet >> rawDo: aZeroArgBlock [
 			status := self moveNext]
 ]
 
-{ #category : #binding }
+{ #category : 'binding' }
 ODBCResultSet >> realize [
 	"Private - Recreate the result set."
 
 	self bind
 ]
 
-{ #category : #mutating }
+{ #category : 'mutating' }
 ODBCResultSet >> resize: anInteger [
 	"ODBCResultSets are not extensible."
 
 	^ self shouldNotImplement
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 ODBCResultSet >> reverse [
 	"Answer a new <sequencedReadableCollection> which contains the same elements
 	as the receiver, but in reverse order."
@@ -610,7 +612,7 @@ ODBCResultSet >> reverse [
 	^ answer
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 ODBCResultSet >> reverseDo: operation [
 	"Evaluate the <monadicValuable> argument, operation, against each
 	element of the receiver in reverse order, from end to start."
@@ -622,13 +624,13 @@ ODBCResultSet >> reverseDo: operation [
 			  object := self previous ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCResultSet >> scrollTo: anInteger [
 
 	^ self fetchScroll: SQL_FETCH_ABSOLUTE offset: anInteger
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 ODBCResultSet >> select: discriminator [
 	"Evaluate the monadic valuable argument, discriminator, for each of the receiver's elements.
 	Answer a new Collection like the receiver containing only those elements for which
@@ -642,7 +644,7 @@ ODBCResultSet >> select: discriminator [
 	^ newCollection
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCResultSet >> size [
 	"Answer the size of the receiver's result set."
 
@@ -658,7 +660,7 @@ ODBCResultSet >> size [
 	^ rowCount < 0 ifTrue: [self countElements] ifFalse: [rowCount]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 ODBCResultSet >> species [
 	"Answer the species of ODBCResultSets.
 	Although the receiver is not extensible, when copying it helps to create an
@@ -668,14 +670,14 @@ ODBCResultSet >> species [
 	^ OrderedCollection
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCResultSet >> statement [
 	"Private - Answer the statement instance variable"
 
 	^ statement
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCResultSet >> statement: anODBCStatement [
 	"Private - Set the statement instance variable to anODBCStatement."
 
@@ -684,7 +686,7 @@ ODBCResultSet >> statement: anODBCStatement [
 	self bind
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCResultSet >> statementHandle [
 	"Private - Answer the handle of the associated statement."
 
@@ -694,7 +696,7 @@ ODBCResultSet >> statementHandle [
 	^ hStmt
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 ODBCResultSet >> with: otherCollection do: operation [
 	"Evaluate the <dyadicValuable> argument, operation, with each of
 	the receiver's elements along with the corresponding element from the

--- a/src/ODBC-Core/ODBCRow.class.st
+++ b/src/ODBC-Core/ODBCRow.class.st
@@ -4,25 +4,27 @@ An ODBCRow respresents a snapshot of a row in a <ODBCResultSet>, the contents of
 Based on DBRow from Dolphin Smalltalk Database Connection package.
 "
 Class {
-	#name : #ODBCRow,
-	#superclass : #ODBCAbstractRow,
-	#category : #'ODBC-Core-Base'
+	#name : 'ODBCRow',
+	#superclass : 'ODBCAbstractRow',
+	#category : 'ODBC-Core-Base',
+	#package : 'ODBC-Core',
+	#tag : 'Base'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 ODBCRow class >> fromBuffer: anODBCRow [
 	^self new
 		initializeFromBuffer: anODBCRow
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 ODBCRow >> asObject [
 	"Private - Answer the receiver as an instance of ODBCRow containing the receiver's values."
 
 	^ self
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 ODBCRow >> initializeFromBuffer: anODBCRow [
 
 	columns := anODBCRow columns.

--- a/src/ODBC-Core/ODBCRowBuffer.class.st
+++ b/src/ODBC-Core/ODBCRowBuffer.class.st
@@ -4,19 +4,21 @@ ODBCRowBuffers are used to describe and buffer the columns of the current row in
 Based on DBRowBuffer from Dolphin Smalltalk Database Connection package.
 "
 Class {
-	#name : #ODBCRowBuffer,
-	#superclass : #ODBCAbstractRow,
-	#category : #'ODBC-Core-Base'
+	#name : 'ODBCRowBuffer',
+	#superclass : 'ODBCAbstractRow',
+	#category : 'ODBC-Core-Base',
+	#package : 'ODBC-Core',
+	#tag : 'Base'
 }
 
-{ #category : #converting }
+{ #category : 'converting' }
 ODBCRowBuffer >> asObject [
 	"Private - Answer the receiver as an instance of ODBCRow containing the receiver's values."
 
 	^ ODBCRow fromBuffer: self
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 ODBCRowBuffer >> bind: aDBStatement [
 	"Private - Bind the receiver's field buffers to columns in the result table."
 
@@ -28,7 +30,7 @@ ODBCRowBuffer >> bind: aDBStatement [
 	^ hStmt
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCRowBuffer >> contents [
 	"Answer the contents instance variable."
 
@@ -36,7 +38,7 @@ ODBCRowBuffer >> contents [
 	^ contents
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCRowBuffer >> objects [
 	"Private - Answer the receivers contents as an <Array> of <Object>s
 	representing the value of each column."
@@ -44,14 +46,14 @@ ODBCRowBuffer >> objects [
 	^ self contents collect: [:c | c value ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCRowBuffer >> sizeInBytes [
 	"Answer the size of the receiver structure in bytes."
 
 	 ^ self contents inject: 0 into: [:size :f | size + f size ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCRowBuffer >> status [
 
 	^ status value

--- a/src/ODBC-Core/ODBCSchemaStatement.class.st
+++ b/src/ODBC-Core/ODBCSchemaStatement.class.st
@@ -4,35 +4,37 @@ ODBCSchemaStatement is the class of Database Connection statements for querying 
 Based on DBSchemaStatement from Dolphin Smalltalk Database Connection package.
 "
 Class {
-	#name : #ODBCSchemaStatement,
-	#superclass : #ODBCAbstractStatement,
+	#name : 'ODBCSchemaStatement',
+	#superclass : 'ODBCAbstractStatement',
 	#instVars : [
 		'catalogName',
 		'schemaName',
 		'tableName'
 	],
-	#category : #'ODBC-Core-Base'
+	#category : 'ODBC-Core-Base',
+	#package : 'ODBC-Core',
+	#tag : 'Base'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 ODBCSchemaStatement class >> isAbstract [
 
 	^ self == ODBCSchemaStatement
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCSchemaStatement >> catalogName [
 
 	^ catalogName
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCSchemaStatement >> catalogName: aString [
 
 	catalogName := aString
 ]
 
-{ #category : #constants }
+{ #category : 'constants' }
 ODBCSchemaStatement >> defaultCursorType [
 	"Answer the <Symbol>ic name of the default cursor type to be used for statements
 	(one of #dynamic, #forwardOnly, #keysetDriven, #static)."
@@ -40,7 +42,7 @@ ODBCSchemaStatement >> defaultCursorType [
 	^ #forwardOnly
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 ODBCSchemaStatement >> executeStatement [
 	"Private - Execute the database command that the receiver represents.
 	Answer the <integer> return code."
@@ -48,25 +50,25 @@ ODBCSchemaStatement >> executeStatement [
 	^ self subclassResponsibility
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCSchemaStatement >> schemaName [
 
 	^ schemaName
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCSchemaStatement >> schemaName: aStringPattern [
 
 	schemaName := aStringPattern
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCSchemaStatement >> tableName [
 
 	^ tableName
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCSchemaStatement >> tableName: aStringPattern [
 
 	tableName := aStringPattern

--- a/src/ODBC-Core/ODBCSpecialColumnsStatement.class.st
+++ b/src/ODBC-Core/ODBCSpecialColumnsStatement.class.st
@@ -2,29 +2,31 @@
 Based on DBSpecialColumnsStatement from Dolphin Smalltalk Database Connection package.
 "
 Class {
-	#name : #ODBCSpecialColumnsStatement,
-	#superclass : #ODBCSchemaStatement,
+	#name : 'ODBCSpecialColumnsStatement',
+	#superclass : 'ODBCSchemaStatement',
 	#instVars : [
 		'columnType',
 		'scope',
 		'nullable'
 	],
-	#category : #'ODBC-Core-Base'
+	#category : 'ODBC-Core-Base',
+	#package : 'ODBC-Core',
+	#tag : 'Base'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCSpecialColumnsStatement >> columnType [
 
 	^ columnType
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCSpecialColumnsStatement >> columnType: anInteger [
 
 	columnType := anInteger
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 ODBCSpecialColumnsStatement >> executeStatement [
 	"Private - Execute the database command that the receiver represents.
 	Answer the <integer> return code."
@@ -42,25 +44,25 @@ ODBCSpecialColumnsStatement >> executeStatement [
 		nullable: (self nullable ifTrue: [SQL_NULLABLE] ifFalse: [SQL_NO_NULLS])
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCSpecialColumnsStatement >> nullable [
 
 	^ nullable
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCSpecialColumnsStatement >> nullable: aBoolean [
 
 	nullable := aBoolean
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCSpecialColumnsStatement >> scope [
 
 	^ scope
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCSpecialColumnsStatement >> scope: anInteger [
 
 	scope := anInteger

--- a/src/ODBC-Core/ODBCStatement.class.st
+++ b/src/ODBC-Core/ODBCStatement.class.st
@@ -9,15 +9,17 @@ Instance Variables:
 Based on DBStatement from Dolphin Smalltalk Database Connection package.
 "
 Class {
-	#name : #ODBCStatement,
-	#superclass : #ODBCAbstractStatement,
+	#name : 'ODBCStatement',
+	#superclass : 'ODBCAbstractStatement',
 	#instVars : [
 		'sqlString'
 	],
-	#category : #'ODBC-Core-Base'
+	#category : 'ODBC-Core-Base',
+	#package : 'ODBC-Core',
+	#tag : 'Base'
 }
 
-{ #category : #constants }
+{ #category : 'constants' }
 ODBCStatement >> defaultCursorType [
 	"Answer the <Symbol>ic name of the default cursor type to be used for statements
 	(one of #dynamic, #forwardOnly, #keysetDriven, #static).
@@ -27,14 +29,14 @@ ODBCStatement >> defaultCursorType [
 	^ #keysetDriven
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 ODBCStatement >> exec: aString [
 	"Execute the SQL statement aString using the receiver"
 
 	self sqlString: aString; exec
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 ODBCStatement >> executeStatement [
 
 	^ ODBCLibrary default
@@ -43,7 +45,7 @@ ODBCStatement >> executeStatement [
 			textLength: SQL_NTS
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 ODBCStatement >> printOn: aStream [
 	"Print a string representation of self onto aStream"
 
@@ -55,14 +57,14 @@ ODBCStatement >> printOn: aStream [
 		nextPut: $)
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCStatement >> sqlString [
 	"Answer the sqlString instance variable."
 
 	^ sqlString
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCStatement >> sqlString: aString [
 	"Private - Set the sqlString instance variable to aString.
 	N.B. Changing the SQL string after executing the statement (either directly

--- a/src/ODBC-Core/ODBCStatisticsStatement.class.st
+++ b/src/ODBC-Core/ODBCStatisticsStatement.class.st
@@ -4,28 +4,30 @@ ODBCStatisticsStatement is a specialized <ODBCSchemaStatement> for querying abou
 Based on DBStatisticsStatement from Dolphin Smalltalk Database Connection package.
 "
 Class {
-	#name : #ODBCStatisticsStatement,
-	#superclass : #ODBCSchemaStatement,
+	#name : 'ODBCStatisticsStatement',
+	#superclass : 'ODBCSchemaStatement',
 	#instVars : [
 		'type',
 		'accurate'
 	],
-	#category : #'ODBC-Core-Base'
+	#category : 'ODBC-Core-Base',
+	#package : 'ODBC-Core',
+	#tag : 'Base'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCStatisticsStatement >> accurate [
 
 	^ accurate
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCStatisticsStatement >> accurate: aBoolean [
 
 	accurate := aBoolean
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 ODBCStatisticsStatement >> executeStatement [
 	"Private - Execute the database command that the receiver represents.
 	Answer the <integer> return code."
@@ -42,7 +44,7 @@ ODBCStatisticsStatement >> executeStatement [
 		reserved: (accurate ifTrue: [SQL_ENSURE] ifFalse: [SQL_QUICK])
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ODBCStatisticsStatement >> initialize: anODBCConnection [
 	"Private - Initialize the receiver as a new statement of the
 	<ODBCConnection>, anODBCConnection."
@@ -52,19 +54,19 @@ ODBCStatisticsStatement >> initialize: anODBCConnection [
 	accurate := false
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCStatisticsStatement >> type [
 
 	^ type
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCStatisticsStatement >> type: statisticsTypeInteger [
 
 	type := statisticsTypeInteger
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCStatisticsStatement >> unique: aBoolean [
 
 	self type: (aBoolean ifTrue: [SQL_INDEX_UNIQUE] ifFalse: [SQL_INDEX_ALL])

--- a/src/ODBC-Core/ODBCStringEncoder.class.st
+++ b/src/ODBC-Core/ODBCStringEncoder.class.st
@@ -2,46 +2,48 @@
 Provides encoding/decoding of Unicode strings.
 "
 Class {
-	#name : #ODBCStringEncoder,
-	#superclass : #Object,
+	#name : 'ODBCStringEncoder',
+	#superclass : 'Object',
 	#instVars : [
 		'characterEncoder'
 	],
-	#category : #'ODBC-Core-Base'
+	#category : 'ODBC-Core-Base',
+	#package : 'ODBC-Core',
+	#tag : 'Base'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 ODBCStringEncoder class >> isAbstract [
 
 	^ self == ODBCStringEncoder
 ]
 
-{ #category : #encoding }
+{ #category : 'encoding' }
 ODBCStringEncoder >> byteSizeForCharacters: anInteger [
 
 	^anInteger * self bytesPerCharacter
 ]
 
-{ #category : #encoding }
+{ #category : 'encoding' }
 ODBCStringEncoder >> byteSizeForString: aString [
 
 	^ self byteSizeForCharacters: aString size
 ]
 
-{ #category : #constants }
+{ #category : 'constants' }
 ODBCStringEncoder >> bytesPerCharacter [
 
 	^ self subclassResponsibility
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCStringEncoder >> characterEncoder [
 	"Appears to lose endian-ness (at image start?) so always reset"
 
 	^ characterEncoder beLittleEndian
 ]
 
-{ #category : #constants }
+{ #category : 'constants' }
 ODBCStringEncoder >> characterEncoderClass [
 
 	"Return the appropriate ZnCharacterEncoder subclass for the receiver"
@@ -49,50 +51,50 @@ ODBCStringEncoder >> characterEncoderClass [
 	^self subclassResponsibility
 ]
 
-{ #category : #decoding }
+{ #category : 'decoding' }
 ODBCStringEncoder >> decodeNullTerminatedStringFrom: aByteArray [
 
 	^ (self characterEncoder decodeBytes: aByteArray) readStream upTo: Character null
 ]
 
-{ #category : #decoding }
+{ #category : 'decoding' }
 ODBCStringEncoder >> decodeStringFrom: aByteArray byteCount: anInteger [
 
 	^ self characterEncoder decodeBytes: (aByteArray first: anInteger)
 ]
 
-{ #category : #decoding }
+{ #category : 'decoding' }
 ODBCStringEncoder >> decodeStringFrom: aByteArray characterCount: anInteger [
 
 	^ self decodeStringFrom: aByteArray byteCount: (self byteSizeForCharacters: anInteger)
 ]
 
-{ #category : #encoding }
+{ #category : 'encoding' }
 ODBCStringEncoder >> encodeString: aString [
 
 	^ aString ifNotNil: [self characterEncoder encodeString: aString]
 ]
 
-{ #category : #encoding }
+{ #category : 'encoding' }
 ODBCStringEncoder >> encodeStringWithNullTerminator: aString [
 
 	^ aString ifNotNil: [(self encodeString: aString), self nullTerminatorBytes]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ODBCStringEncoder >> initialize [
 
 	characterEncoder := self characterEncoderClass new beLittleEndian
 ]
 
-{ #category : #constants }
+{ #category : 'constants' }
 ODBCStringEncoder >> nullTerminatorBytes [
 	"Should be size == self bytesPerCharacter"
 
 	^ self subclassResponsibility
 ]
 
-{ #category : #encoding }
+{ #category : 'encoding' }
 ODBCStringEncoder >> stringBufferFor: anInteger [
 	"Create, allocate and return a buffer (ExternalAddress) to hold anInteger characters in the receiver's encoding"
 

--- a/src/ODBC-Core/ODBCTablesStatement.class.st
+++ b/src/ODBC-Core/ODBCTablesStatement.class.st
@@ -4,15 +4,17 @@ ODBCTablesStatement is a specialized <ODBCSchemaStatement> for querying about ta
 Based on DBTablesStatement from Dolphin Smalltalk Database Connection package.
 "
 Class {
-	#name : #ODBCTablesStatement,
-	#superclass : #ODBCSchemaStatement,
+	#name : 'ODBCTablesStatement',
+	#superclass : 'ODBCSchemaStatement',
 	#instVars : [
 		'tableType'
 	],
-	#category : #'ODBC-Core-Base'
+	#category : 'ODBC-Core-Base',
+	#package : 'ODBC-Core',
+	#tag : 'Base'
 }
 
-{ #category : #operations }
+{ #category : 'operations' }
 ODBCTablesStatement >> executeStatement [
 	"Private - Execute the database command that the receiver represents.
 	Answer the <integer> return code."
@@ -29,7 +31,7 @@ ODBCTablesStatement >> executeStatement [
 		cbTableType: SQL_NTS
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ODBCTablesStatement >> initialize: anODBCConnection [
 	"Private - Initialize the receiver as a new statement of the
 	<ODBCConnection>, anODBCConnection."
@@ -38,13 +40,13 @@ ODBCTablesStatement >> initialize: anODBCConnection [
 	tableType := '''TABLE'''
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCTablesStatement >> tableType [
 
 	^ tableType
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCTablesStatement >> tableType: aString [
 
 	tableType := aString

--- a/src/ODBC-Core/ODBCTxn.class.st
+++ b/src/ODBC-Core/ODBCTxn.class.st
@@ -11,8 +11,8 @@ Instance Variables:
 Based on DBTxn from Dolphin Smalltalk Database Connection package.
 "
 Class {
-	#name : #ODBCTxn,
-	#superclass : #Object,
+	#name : 'ODBCTxn',
+	#superclass : 'Object',
 	#instVars : [
 		'connection',
 		'readOnly',
@@ -21,10 +21,12 @@ Class {
 	#pools : [
 		'ODBCConstants'
 	],
-	#category : #'ODBC-Core-Base'
+	#category : 'ODBC-Core-Base',
+	#package : 'ODBC-Core',
+	#tag : 'Base'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 ODBCTxn class >> newOn: anODBCConnection [
 	"Answer an instance of the receiver with commits disabled."
 
@@ -34,7 +36,7 @@ ODBCTxn class >> newOn: anODBCConnection [
 			yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 ODBCTxn class >> newRWOn: anODBCConnection [
 	"Answer an instance of the receiver with commits enabled."
 
@@ -44,21 +46,21 @@ ODBCTxn class >> newRWOn: anODBCConnection [
 			yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCTxn >> beReadOnly [
 	"Set the receiver's readOnly inst var to true."
 
 	readOnly := true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCTxn >> beReadWrite [
 	"Set the receiver's readOnly inst var to false."
 
 	readOnly := false
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 ODBCTxn >> commit [
 	"Commit the transaction."
 
@@ -67,21 +69,21 @@ ODBCTxn >> commit [
 	ODBCConnection transact: connection action: SQL_COMMIT
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ODBCTxn >> connection [
 	"Answer the connection instance variable."
 
 	^ connection
 ]
 
-{ #category : #initializing }
+{ #category : 'initializing' }
 ODBCTxn >> connection: anODBCConnection [
 	"Private - Set the connection instance variable to anODBCConnection."
 
 	connection := anODBCConnection
 ]
 
-{ #category : #development }
+{ #category : 'development' }
 ODBCTxn >> creator: anObject [
 	"Private - Set the creator instance variable to anObject."
 
@@ -89,7 +91,7 @@ ODBCTxn >> creator: anObject [
 	self transcriptMessage: 'New transaction...'
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 ODBCTxn >> printOn: aStream [
 	"Print a text representation of the receiver on aStream."
 
@@ -106,7 +108,7 @@ ODBCTxn >> printOn: aStream [
 		nextPut: $)
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 ODBCTxn >> rollback [
 	"Free up all resources held by the tuples opened during this
 	transaction"
@@ -115,7 +117,7 @@ ODBCTxn >> rollback [
 	ODBCConnection transact: connection action: SQL_ROLLBACK
 ]
 
-{ #category : #'operations-logging' }
+{ #category : 'operations-logging' }
 ODBCTxn >> transcriptMessage: aString [
 	"Private - Output an appropriately annotated message to the current
 	session's trace device. In a development session this is the Transcript"

--- a/src/ODBC-Core/ODBCUTF16Encoder.class.st
+++ b/src/ODBC-Core/ODBCUTF16Encoder.class.st
@@ -2,24 +2,26 @@
 Provides encoding/decoding of UTF16 strings.
 "
 Class {
-	#name : #ODBCUTF16Encoder,
-	#superclass : #ODBCStringEncoder,
-	#category : #'ODBC-Core-Base'
+	#name : 'ODBCUTF16Encoder',
+	#superclass : 'ODBCStringEncoder',
+	#category : 'ODBC-Core-Base',
+	#package : 'ODBC-Core',
+	#tag : 'Base'
 }
 
-{ #category : #constants }
+{ #category : 'constants' }
 ODBCUTF16Encoder >> bytesPerCharacter [
 
 	^ 2
 ]
 
-{ #category : #constants }
+{ #category : 'constants' }
 ODBCUTF16Encoder >> characterEncoderClass [
 
 	^ ZnUTF16Encoder
 ]
 
-{ #category : #decoding }
+{ #category : 'decoding' }
 ODBCUTF16Encoder >> decodeNullTerminatedStringFrom: aByteArray [
 	"Optimised (~25% faster) equivalent of superclass implementation"
 
@@ -48,7 +50,7 @@ ODBCUTF16Encoder >> decodeNullTerminatedStringFrom: aByteArray [
 	^ stream contents
 ]
 
-{ #category : #decoding }
+{ #category : 'decoding' }
 ODBCUTF16Encoder >> decodeStringFrom: aByteArray byteCount: anInteger [
 	"Optimised (~25% faster) equivalent of superclass implementation"
 
@@ -78,7 +80,7 @@ ODBCUTF16Encoder >> decodeStringFrom: aByteArray byteCount: anInteger [
 	^ stream contents
 ]
 
-{ #category : #constants }
+{ #category : 'constants' }
 ODBCUTF16Encoder >> nullTerminatorBytes [
 
 	^ #[ 0 0 ]

--- a/src/ODBC-Core/ODBCUTF32Encoder.class.st
+++ b/src/ODBC-Core/ODBCUTF32Encoder.class.st
@@ -2,24 +2,26 @@
 Provided encoding/decoding of UTF32 strings.
 "
 Class {
-	#name : #ODBCUTF32Encoder,
-	#superclass : #ODBCStringEncoder,
-	#category : #'ODBC-Core-Base'
+	#name : 'ODBCUTF32Encoder',
+	#superclass : 'ODBCStringEncoder',
+	#category : 'ODBC-Core-Base',
+	#package : 'ODBC-Core',
+	#tag : 'Base'
 }
 
-{ #category : #constants }
+{ #category : 'constants' }
 ODBCUTF32Encoder >> bytesPerCharacter [
 
 	^ 4
 ]
 
-{ #category : #constants }
+{ #category : 'constants' }
 ODBCUTF32Encoder >> characterEncoderClass [
 
 	^ ZnUTF32Encoder
 ]
 
-{ #category : #constants }
+{ #category : 'constants' }
 ODBCUTF32Encoder >> nullTerminatorBytes [
 
 	^ #[ 0 0 0 0 ]

--- a/src/ODBC-Core/ODBCUnboundBuffer.class.st
+++ b/src/ODBC-Core/ODBCUnboundBuffer.class.st
@@ -4,12 +4,14 @@ An ODBCUnboundRow represents a row buffer that is not statically bound to alloca
 Based on ODBCUnboundBuffer from Dolphin Smalltalk Database Connection package.
 "
 Class {
-	#name : #ODBCUnboundBuffer,
-	#superclass : #ODBCRowBuffer,
-	#category : #'ODBC-Core-Base'
+	#name : 'ODBCUnboundBuffer',
+	#superclass : 'ODBCRowBuffer',
+	#category : 'ODBC-Core-Base',
+	#package : 'ODBC-Core',
+	#tag : 'Base'
 }
 
-{ #category : #'data retrieval' }
+{ #category : 'data retrieval' }
 ODBCUnboundBuffer >> getData: anODBCStatement [
 	"Private - Copy data from the result table into fields of the receiver."
 

--- a/src/ODBC-Core/ODBCWarning.class.st
+++ b/src/ODBC-Core/ODBCWarning.class.st
@@ -4,19 +4,21 @@ Instances of ODBCWarning hold exception information for Database Connection non-
 Based on DBWarning from Dolphin Smalltalk Database Connection package.
 "
 Class {
-	#name : #ODBCWarning,
-	#superclass : #Notification,
-	#category : #'ODBC-Core-Base'
+	#name : 'ODBCWarning',
+	#superclass : 'Notification',
+	#category : 'ODBC-Core-Base',
+	#package : 'ODBC-Core',
+	#tag : 'Base'
 }
 
-{ #category : #signalling }
+{ #category : 'signalling' }
 ODBCWarning class >> signalWith: anODBCExceptionDetails [
 
 	anODBCExceptionDetails buildErrorInfo.
 	self signal: anODBCExceptionDetails displayString withTag: anODBCExceptionDetails
 ]
 
-{ #category : #signaling }
+{ #category : 'signaling' }
 ODBCWarning >> signal [
 	"Signal this exception."
 

--- a/src/ODBC-Core/package.st
+++ b/src/ODBC-Core/package.st
@@ -1,1 +1,1 @@
-Package { #name : #'ODBC-Core' }
+Package { #name : 'ODBC-Core' }


### PR DESCRIPTION
with @AlessHosry 

In the Pharo 12/Moose 12, this package cannot load anymore, due to the use of WeakRegistry.
The class was refactored into FinalizationRegistry.

We replaced the references in the following methods :
ODBCConnection>>#initializeStatements
ODBCConnection class>>#newConnections

Unfortunately, the new file format has created a lot of noise in the diff.
